### PR TITLE
Add scheduled action to recompute actionable leads

### DIFF
--- a/custom_addons/leads/__manifest__.py
+++ b/custom_addons/leads/__manifest__.py
@@ -10,6 +10,7 @@
         'security/security.xml',
         'security/ir.model.access.csv',
         'data/ir_config_parameter_data.xml',
+        'data/lead_score_cron.xml',
 
         # Defines the wizard's action first, as other views depend on it.
         'views/lead_score_bq_wizard_views.xml',

--- a/custom_addons/leads/data/lead_score_cron.xml
+++ b/custom_addons/leads/data/lead_score_cron.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="ir_cron_recompute_actionable_leads" model="ir.cron">
+            <field name="name">Leads: Recompute Actionable Today Flag</field>
+            <field name="model_id" ref="model_lead_score"/>
+            <field name="state">code</field>
+            <field name="code">model._recompute_actionable_flag()</field>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <!-- Remove this line: <field name="doall" eval="False"/> -->
+        </record>
+
+    </data>
+</odoo>

--- a/custom_addons/leads/models/lead_score.py
+++ b/custom_addons/leads/models/lead_score.py
@@ -153,5 +153,17 @@ class LeadScore(models.Model):
         """ This method is called by the button. """
         action = self.env['ir.actions.act_window']._for_xml_id('leads.action_fetch_leads_wizard')
         return action
+    
 
+    def _recompute_actionable_flag(self):
+        """
+        Scheduled action to re-evaluate the actionale flag for leads that are not yet marked actionable but whose follow-up date is today or earlier.
+    
+        """
+        today = fields.Date.today()
+        leads_to_update = self.search([
+            ('is_actionable_today', '=', False),
+            ('next_follow_up_date', '<=', today)
+        ])
+        leads_to_update._compute_is_actionable_today()
 

--- a/custom_addons/leads/views/lead_score_views.xml
+++ b/custom_addons/leads/views/lead_score_views.xml
@@ -12,10 +12,10 @@
                 <field name="write_date"/> <!-- Added for date-based filtering -->
                 <field name="create_date"/> <!-- Added for date-based filtering -->
                 <filter name="actionable_today" string="Actionable Today" 
-                        domain="[('is_actionable_today', '=', True), ('current_status', '!=', 'option_not_matching_requirements'), ('current_status', '!=', 'no_requirements'), ('current_status', '!=', 'requirement_closed'),('predicted_score', '>=', 0.3)]"
+                        domain="[('is_actionable_today', '=', True), ('current_status', '!=', 'option_not_matching_requirements'),('current_status', '!=', 'site_visit_done'), ('current_status', '!=', 'no_requirements'), ('current_status', '!=', 'requirement_closed'),('predicted_score', '>=', 0.3)]"
                         help="Leads that need follow-up today or are overdue"/>
                 <filter name="future_follow_up" string="Future Follow-ups" 
-                        domain="[('is_actionable_today', '=', False), ('current_status', '!=', 'option_not_matching_requirements'), ('current_status', '!=', 'no_requirements'), ('current_status', '!=', 'requirement_closed'),('predicted_score', '>=', 0.3)]"
+                        domain="[('is_actionable_today', '=', False), ('current_status', '!=', 'option_not_matching_requirements'), ('current_status', '!=', 'site_visit_done'), ('current_status', '!=', 'no_requirements'), ('current_status', '!=', 'requirement_closed'),('predicted_score', '>=', 0.3)]"
                         help="Leads scheduled for future follow-up"/>
                 <filter name="recently_updated" string="Recently Updated"
                         domain="[('write_date', '>=', (context_today() - datetime.timedelta(days=7)).strftime('%Y-%m-%d'))]"


### PR DESCRIPTION
Introduces a cron job to periodically update the 'is_actionable_today' flag for leads based on their follow-up date. Also updates lead score filters to exclude 'site_visit_done' status, ensuring more accurate filtering of actionable and future follow-up leads.
