### PR TITLE
Update lead and WhatsApp response options

### DIFF
--- a/custom_addons/leads/models/lead_score.py
+++ b/custom_addons/leads/models/lead_score.py
@@ -24,7 +24,7 @@ class LeadScore(models.Model):
         ('option_not_matching_requirements', 'Option Not Matching Requirements'),
         ('details_shared_of_property', 'Details Shared of Property'),
         ('no_requirements', 'No Requirements'),
-        ('details_shared_and_interested_for_site_visit', 'Details Shared and Interested for Site Visit'),
+        ('detail_shared_and_interested_for_site_visit', 'Detail Shared and Interested for Site Visit'),
         ('switched_off', 'Switched Off'),
         ('requirement_closed', 'Requirement Closed'),
         ('property_sold_out', 'Property Sold Out'),

--- a/custom_addons/leads/models/whatsapp_response.py
+++ b/custom_addons/leads/models/whatsapp_response.py
@@ -17,6 +17,8 @@ class WhatsAppResponse(models.Model):
         ('reschedule_visit', 'Reschedule visit'),
         ('liked_property', 'Liked Property'),
         ('more_options', 'More Options'),
+        ('going_for_site_visit', 'Going for site visit'),
+        ('need_support', 'Need Support'),
     ], string='Response', required=True)
 
     # Related fields


### PR DESCRIPTION
Corrected a typo in the LeadScore response option and added two new response options to WhatsAppResponse: 'Going for site visit' and 'Need Support'.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
