### PR TITLE
Add 'Generic Response' option to WhatsAppResponse

### DIFF
--- a/custom_addons/leads/models/whatsapp_response.py
+++ b/custom_addons/leads/models/whatsapp_response.py
@@ -20,6 +20,7 @@ class WhatsAppResponse(models.Model):
         ('more_options', 'More Options'),
         ('going_for_site_visit', 'Going for site visit'),
         ('need_support', 'Need Support'),
+        ('generic_response', 'Generic Response')
     ], string='Response', required=True)
 
     # Related fields

--- a/custom_addons/leads/views/whatsapp_response_views.xml
+++ b/custom_addons/leads/views/whatsapp_response_views.xml
@@ -205,7 +205,7 @@
                         <group>
                             <field name="lead_id" options="{'no_create': True}"/>
                             <field name="number"/>
-                            <field name="response" widget="badge" style="font-size: 1.1rem;"/>
+                            <field name="response" style="font-size: 1.1rem;"/>
                             <field name="response_date"/>
                         </group>
                         <group>


### PR DESCRIPTION
Introduces a new 'generic_response' selection to the response field in WhatsAppResponse. Also removes the 'badge' widget from the response field in the form view for improved display consistency.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
