### PR TITLE
Add 'Successfully Visited' option to WhatsAppResponse

### DIFF
--- a/custom_addons/leads/models/whatsapp_response.py
+++ b/custom_addons/leads/models/whatsapp_response.py
@@ -18,6 +18,7 @@ class WhatsAppResponse(models.Model):
         ('reschedule_visit', 'Reschedule visit'),
         ('liked_property', 'Liked Property'),
         ('more_options', 'More Options'),
+        ('successfully_visited', 'Successfully Visited'),
         ('going_for_site_visit', 'Going for site visit'),
         ('need_support', 'Need Support'),
         ('generic_response', 'Generic Response')


### PR DESCRIPTION
Introduced a new selection value 'successfully_visited' to the WhatsAppResponse model to capture when a user has successfully visited a property.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
