### PR TITLE
Refactor lead feedback fields and update filters

### DIFF
--- a/custom_addons/leads/models/lead_score.py
+++ b/custom_addons/leads/models/lead_score.py
@@ -58,12 +58,24 @@ class LeadScore(models.Model):
     # Fields for RM Interaction
     site_visit_scheduled_date = fields.Date(string='Site Visit Scheduled For Date')
     #feedback = fields.Text(string='Feedback')
-    feedback = fields.Selection([
+
+    feedback_general = fields.Selection([
         ('buyer_did_not_visit_property', 'Buyer Did Not Visit Property'),
         ('buyer_not_interested', 'Buyer Not Interested'),
         ('buyer_not_picking_call', 'Buyer Not Picking Call'),
         ('visit_needs_to_be_rescheduled', 'Visit Needs to be Rescheduled'),
+        ('other', 'Other'),
     ], string='Feedback')
+
+    feedback_site_visit_done = fields.Selection([
+        ('requirements_not_matching', 'Requirements Not Matching'),
+        ('buyer_liked_property', 'Buyer Liked Property'),
+        ('buyer_requirement_closed', 'Buyer Requirement Closed'),
+        ('buyer_visit_from_outside', 'Buyer Visit From Outside'),
+        ('buyer_not_pickup_call', 'Buyer Not Picking Call'),
+        ('other', 'Other')
+    ], string='Feedback for Site Visit Done')
+
     next_follow_up_date = fields.Date(
         string='Next Follow-up Date',
         compute = '_compute_next_follow_up_date',
@@ -90,6 +102,8 @@ class LeadScore(models.Model):
         ('site_visit_done', 'Site Visit Done'),
         ('other', 'Other')
     ], string='Status', default='lead', required=True)
+
+    notes = fields.Text(string='Notes')
 
     is_actionable_today = fields.Boolean(
         string='Is Actionable Today',

--- a/custom_addons/leads/views/lead_score_views.xml
+++ b/custom_addons/leads/views/lead_score_views.xml
@@ -12,10 +12,10 @@
                 <field name="write_date"/> <!-- Added for date-based filtering -->
                 <field name="create_date"/> <!-- Added for date-based filtering -->
                 <filter name="actionable_today" string="Actionable Today" 
-                        domain="[('is_actionable_today', '=', True), ('current_status', '!=', 'option_not_matching_requirements'),('current_status', '!=', 'site_visit_done'), ('current_status', '!=', 'no_requirements'), ('current_status', '!=', 'requirement_closed'),('predicted_score', '>=', 0.3)]"
+                        domain="[('is_actionable_today', '=', True), ('current_status', '!=', 'option_not_matching_requirements'),('current_status', '!=', 'site_visit_done'), ('current_status', '!=', 'property_sold_out') ,('current_status', '!=', 'no_requirements'), ('current_status', '!=', 'requirement_closed'),('predicted_score', '>=', 0.3)]"
                         help="Leads that need follow-up today or are overdue"/>
                 <filter name="future_follow_up" string="Future Follow-ups" 
-                        domain="[('is_actionable_today', '=', False), ('current_status', '!=', 'option_not_matching_requirements'), ('current_status', '!=', 'site_visit_done'), ('current_status', '!=', 'no_requirements'), ('current_status', '!=', 'requirement_closed'),('predicted_score', '>=', 0.3)]"
+                        domain="[('is_actionable_today', '=', False), ('current_status', '!=', 'option_not_matching_requirements'), ('current_status', '!=', 'site_visit_done'), ('current_status', '!=', 'property_sold_out'), ('current_status', '!=', 'no_requirements'), ('current_status', '!=', 'requirement_closed'),('predicted_score', '>=', 0.3)]"
                         help="Leads scheduled for future follow-up"/>
                 <filter name="recently_updated" string="Recently Updated"
                         domain="[('write_date', '>=', (context_today() - datetime.timedelta(days=7)).strftime('%Y-%m-%d'))]"
@@ -136,7 +136,9 @@
                             </group>
                         </page>
                         <page string="Feedback">
-                            <field name="feedback" placeholder="Select appropriate feedback"/>
+                            <field name="feedback_general" placeholder="Select Appropriate Feedback" string="Feedback" invisible = "current_status == 'site_visit_done'"/>
+                            <field name="feedback_site_visit_done" placeholder="Select appropriate feedback" string = "Feedback" invisible = "current_status != 'site_visit_done'"/>
+                            <field name="notes" placeholder="Additional notes..."/>
                         </page>
                         <page string="WhatsApp Responses">
                             <field name="whatsapp_response_ids" 

--- a/custom_addons/leads/views/whatsapp_response_views.xml
+++ b/custom_addons/leads/views/whatsapp_response_views.xml
@@ -195,11 +195,7 @@
                     <widget name="web_ribbon" 
                             text="Positive" 
                             bg_color="bg-success"
-                            invisible="[('response_type', '!=', 'positive')]"/>
-                    <widget name="web_ribbon" 
-                            text="Negative" 
-                            bg_color="bg-danger"
-                            invisible="[('response_type', '!=', 'negative')]"/>
+                            invisible = "response_type != 'positive'" />
                     
                     <group>
                         <group>


### PR DESCRIPTION
Split the feedback field into 'feedback_general' and 'feedback_site_visit_done' for more granular tracking, and added a 'notes' field. Updated lead score filters to exclude 'property_sold_out' status. Adjusted feedback visibility in views and simplified WhatsApp response ribbon logic.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
