### PR TITLE
Add all_associated_properties field and update lead assignment logic

### DIFF
--- a/custom_addons/leads/models/new_portal_leads.py
+++ b/custom_addons/leads/models/new_portal_leads.py
@@ -143,7 +143,16 @@ class NewPortalLead(models.Model):
     interest_ids = fields.One2many(
         'lead.property.interest',
         'lead_id',
-        string="Recommended Properies"
+        string="Recommended Properies",
+        store = True
+    )
+
+    all_associated_properties = fields.Many2many(
+        'property.inventory',
+        string="All Associated Properties",
+        compute='_compute_all_associated_properties',
+        store=True,
+        help="Includes both the primary and recommended properties."
     )
 
     create_date_only = fields.Date(
@@ -154,6 +163,20 @@ class NewPortalLead(models.Model):
     )
     
     # --- Compute Methods ---
+
+    @api.depends('property_id', 'interest_ids.property_id')
+    def _compute_all_associated_properties(self):
+        """
+        Combines the primary property and all recommended properties
+        into a single Many2many field for easy access.
+        """
+        for lead in self:
+            properties = lead.property_id
+
+            if lead.interest_ids:
+                properties |= lead.interest_ids.mapped('property_id')
+                
+            lead.all_associated_properties = properties
 
     @api.depends('create_date')
     def _compute_create_date_only(self):
@@ -342,6 +365,7 @@ class NewPortalLead(models.Model):
     def _process_lead_logic(self):
         """
         This now runs in the same transaction as the cron job.
+        Updated: If Property is not found, assigns to 'Naresh Rojiya'
         """
         self.ensure_one()
         _logger.info(f"🔄 Processing lead {self.id}: {self.name} (state: {self.state})")
@@ -352,24 +376,36 @@ class NewPortalLead(models.Model):
         
         try:
             property_rec = self._find_property()
+            rm_user = False
+            notes = ""
+
+            if property_rec:
+                _logger.info(f"✅ Lead {self.id}: Found property {property_rec.property_tag} (ID: {property_rec.id})")
+                rm_user = self._find_rm(property_rec)
+                _logger.info(f"✅ Lead {self.id}: Found RM {rm_user.name} (ID: {rm_user.id})")
+                notes = f"Successfully assigned to RM {rm_user.name} for property {property_rec.property_tag}.\n"
             
             if not property_rec:
-                msg = f"Attempt {fields.Datetime.now()}: Property not found for {self.portal_name} ID: {self.portal_property_id}"
-                _logger.warning(f"⚠️ Lead {self.id}: {msg}")
-                self.process_notes = msg + "\n"
-                return
-            
-            _logger.info(f"✅ Lead {self.id}: Found property {property_rec.property_tag} (ID: {property_rec.id})")
-            
-            rm_user = self._find_rm(property_rec)
-            _logger.info(f"✅ Lead {self.id}: Found RM {rm_user.name} (ID: {rm_user.id})")
+                msg = f"Property not found for {self.portal_name} ID: {self.portal_property_id}"
+                _logger.warning(f"⚠️ Lead {self.id}: {msg}. Attempting to assign to default RM.")
+
+                rm_user = self.env['res.users'].search([('name', 'ilike', 'Naresh Rojiya')], limit=1)
+
+                if not rm_user:
+                    # Safety Fallback: If Naresh is not found in the system, assign to Admin to prevent error
+                    _logger.error("User 'Naresh Rojiya' not found. Assigning to Administrator.")
+                    rm_user = self.env.ref('base.user_admin')
+
+                notes = f"{msg}\nAssigned to Default RM: {rm_user.name}.\n"
+
 
             self.write({
-                'property_id': property_rec.id,
+                'property_id': property_rec.id if property_rec else False,
                 'user_id': rm_user.id,
                 'state': 'assigned',
-                'process_notes': f"Successfully assigned to RM {rm_user.name} for property {property_rec.property_tag}.\n"
+                'process_notes': notes
             })
+
             _logger.info(f"🎉 Lead {self.id}: Successfully assigned to {rm_user.name} for property {property_rec.property_tag}")
 
         except Exception as e:

--- a/custom_addons/leads/security/ir.model.access.csv
+++ b/custom_addons/leads/security/ir.model.access.csv
@@ -7,5 +7,5 @@ access_lead_score_bq_wizard,lead.score.bq.wizard,model_lead_score_bq_wizard,lead
 access_lead_csv_import_wizard,access.lead.csv.import.wizard,model_lead_csv_import_wizard,leads.group_lead_score_manager,1,1,1,1
 access_message_wizard,access.message.wizard,model_message_wizard,base.group_user,1,1,1,1
 access_leads_new_manager,leads.new.manager,model_leads_new,leads.group_lead_score_manager,1,1,1,1
-access_leads_new_rm,leads.new.rm,model_leads_new,leads.group_lead_score_rm,1,1,1,1
+access_leads_new_rm,leads.new.rm,model_leads_new,leads.group_lead_score_rm,1,1,1,0
 access_lead_property_interest_rm,lead.property.interest.rm,model_lead_property_interest,leads.group_lead_score_rm,1,1,1,1

--- a/custom_addons/leads/views/new_portal_lead_views.xml
+++ b/custom_addons/leads/views/new_portal_lead_views.xml
@@ -4,7 +4,7 @@
     <!-- ================================================ -->
     <!--  SEARCH VIEW – TIMEZONE-SAFE (uses create_date_only) -->
     <!-- ================================================ -->
-    <record id="leads_new_view_search" model="ir.ui.view">
+<record id="leads_new_view_search" model="ir.ui.view">
         <field name="name">leads.new.search</field>
         <field name="model">leads.new</field>
         <field name="arch" type="xml">
@@ -14,7 +14,10 @@
                 <field name="phone"/>
                 <field name="user_id" string="RM"/>
                 <field name="property_location"/>
-                <field name="property_id"/>
+                
+                <field name="all_associated_properties" string="Property (Primary or Recommended)"/>
+                
+                <field name="property_id" string="Primary Property Only"/>
                 <field name="property_bhk"/>
                 <field name="property_city"/>
                 <field name="portal_name"/>
@@ -75,6 +78,11 @@
                 <group expand="1" string="Group By">
                     <filter string="Current Status" name="groupby_status" context="{'group_by': 'current_status'}"/>
                     <filter string="RM"             name="groupby_user"   context="{'group_by': 'user_id'}"/>
+                    
+                    <filter string="Property (All Associated)" 
+                            name="groupby_all_props" 
+                            context="{'group_by': 'all_associated_properties'}"/>
+                            
                     <filter string="Main State"     name="groupby_state"  context="{'group_by': 'state'}"/>
                     <filter string="Portal"         name="groupby_portal" context="{'group_by': 'portal_name'}"/>
                     <filter string="Creation Date"  name="groupby_date"   context="{'group_by': 'create_date_only'}"/>


### PR DESCRIPTION
Introduces a computed Many2many field 'all_associated_properties' to aggregate primary and recommended properties for leads. Updates the lead assignment logic to assign leads without a found property to a default RM ('Naresh Rojiya'), with a fallback to the admin user if necessary. Adjusts the search view to support filtering and grouping by all associated properties. Also updates RM access rights to remove delete permissions.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
