### PR TITLE
Update measure field in workflow overview graph

### DIFF
--- a/custom_addons/cleardeals_dashboards/views/new_lead_dashboard_views.xml
+++ b/custom_addons/cleardeals_dashboards/views/new_lead_dashboard_views.xml
@@ -147,7 +147,7 @@
             <graph string="Workflow Overview" type="bar" stacked="True" sample="1">
                 <field name="lead_create_date_only" interval="day"/>
                 <field name="assigned_rm"/>
-                <field name="cnt_initial_msg" type="measure"/>
+                <field name="__count" type="measure"/>
             </graph>
         </field>
     </record>


### PR DESCRIPTION
Replaces 'cnt_initial_msg' with '__count' as the measure field in the Workflow Overview bar graph for the new lead dashboard.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
