### PR TITLE
Add test suite documentation and new boolean field

### DIFF
--- a/custom_addons/cleardeals_dashboards/tests/README.md
+++ b/custom_addons/cleardeals_dashboards/tests/README.md
@@ -1,0 +1,658 @@
+# ClearDeals Dashboards Module - Test Suite Documentation
+
+> **Odoo 19 Custom Module Testing Documentation**  
+> **Module:** `cleardeals_dashboards`  
+> **Path:** `/custom_addons/cleardeals_dashboards/tests/`
+
+---
+
+## 📋 Table of Contents
+
+1. [Overview](#overview)
+2. [Test Architecture](#test-architecture)
+3. [Running Tests](#running-tests)
+4. [Test Files Reference](#test-files-reference)
+5. [Test Coverage Matrix](#test-coverage-matrix)
+6. [Common Test Fixtures](#common-test-fixtures)
+7. [Template System](#template-system)
+8. [Best Practices](#best-practices)
+9. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+This test suite provides comprehensive coverage for the **ClearDeals Lead Scoring Dashboards Module** in Odoo 19. The module provides WhatsApp communication tracking, lead scoring metrics, and event-driven analytics.
+
+### Models Under Test
+
+| Model | Description |
+|-------|-------------|
+| `lead.scoring.lead` | Lead records with scoring, workflow stages, and computed metrics |
+| `lead.scoring.event` | WhatsApp message events (sent, delivered, read, failed, replies) |
+
+### Test Statistics
+
+- **Total Test Files:** 7
+- **Test Categories:** CRUD, Events, Funnel Metrics, Smart Buttons, Template Counts
+- **Test Tags:** `@tagged('post_install', '-at_install')`
+
+---
+
+## Test Architecture
+
+```
+tests/
+├── __init__.py                           # Test module imports
+├── test_lead_scoring_common.py           # Base test fixtures (LeadScoringTestCase)
+│
+├── Lead Model Tests
+│   ├── test_lead_scoring_crud.py         # CRUD operations (7 tests)
+│   ├── test_lead_scoring_funnel.py       # Funnel metrics (8 tests)
+│   ├── test_lead_scoring_metrics.py      # Message counts (8 tests)
+│   ├── test_lead_scoring_template_counts.py  # Template tracking (10 tests)
+│   └── test_lead_scoring_smart_buttons.py    # UI actions (4 tests)
+│
+├── Event Model Tests
+│   └── test_lead_scoring_events.py       # Event relationships (3 tests)
+│
+└── README.md                             # This documentation
+```
+
+---
+
+## Running Tests
+
+### Run All ClearDeals Dashboards Tests
+
+```bash
+# Windows (from project root)
+python odoo-bin -c odoo.conf -d <database_name> --test-enable --stop-after-init -i cleardeals_dashboards
+
+# With specific log level
+python odoo-bin -c odoo.conf -d <database_name> --test-enable --stop-after-init -i cleardeals_dashboards --log-level=test
+```
+
+### Run Specific Test File
+
+```bash
+# Run only funnel tests
+python odoo-bin -c odoo.conf -d <database_name> --test-enable --stop-after-init --test-file=custom_addons/cleardeals_dashboards/tests/test_lead_scoring_funnel.py
+```
+
+### Run Tests by Tag
+
+```bash
+# Run post_install tests only
+python odoo-bin -c odoo.conf -d <database_name> --test-tags=post_install
+```
+
+### Using pytest-odoo (Alternative)
+
+```bash
+pytest custom_addons/cleardeals_dashboards/tests/ -v --odoo-database=<database_name>
+```
+
+---
+
+## Test Files Reference
+
+### 1. `test_lead_scoring_common.py` - Base Test Fixtures
+
+**Purpose:** Provides the `LeadScoringTestCase` base class with shared fixtures and helper methods.
+
+#### Class Variables:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `_phone_counter` | `int` | Counter for unique phone generation |
+| `timestamp` | `str` | Unique identifier for test isolation |
+| `TEMPLATE_TRIGGERS` | `list` | Outbound trigger template names |
+| `TEMPLATE_RESPONSES` | `list` | Response template names |
+
+#### Helper Methods:
+
+```python
+def create_lead(self, **kwargs):
+    """
+    Create a lead with guaranteed unique phone number.
+    
+    Default Values:
+        - lead_name: 'Test Lead'
+        - lead_phone: Auto-generated unique
+        - property_tag: 'PROP-{unique}'
+        - assigned_rm: 'Test RM'
+        - predicted_score: 0.85
+        - current_status: 'lead'
+        - workflow_stage: 'ringing'
+    
+    Returns:
+        lead.scoring.lead: Created lead record
+    """
+
+def create_event(self, lead=None, **kwargs):
+    """
+    Create an event with defaults.
+    
+    Default Values:
+        - event_id: Auto-generated unique
+        - correlation_id: Auto-generated unique
+        - event_timestamp: now()
+        - event_type: 'message_sent'
+        - message_direction: 'outbound'
+        - template_name: 'ringing'
+    
+    Returns:
+        lead.scoring.event: Created event record
+    """
+
+def create_outbound_sent_event(self, lead, template_name, correlation_id=None):
+    """Create a message_sent outbound event."""
+
+def create_status_event(self, lead, status_type, correlation_id):
+    """Create a status event (delivered/read/failed)."""
+
+def create_inbound_event(self, lead, message_content='Customer reply'):
+    """Create an inbound message event."""
+```
+
+---
+
+### 2. `test_lead_scoring_crud.py` - Lead CRUD Operations
+
+**Class:** `TestLeadScoringCRUD(LeadScoringTestCase)`  
+**Model Under Test:** `lead.scoring.lead`  
+**Total Tests:** 7
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_create_lead_with_required_fields` | Basic lead creation |
+| 02 | `test_02_lead_phone_required` | Phone DB constraint |
+| 03 | `test_03_unique_phone_constraint` | Unique phone enforcement |
+| 04 | `test_04_default_values` | Default computed fields |
+| 05 | `test_05_workflow_stage_values` | Valid workflow stages |
+| 06 | `test_06_optional_fields_storage` | Optional field persistence |
+| 07 | `test_07_lead_ordering` | Order by last_activity desc |
+
+#### Valid Workflow Stages:
+
+```python
+[
+    'ringing',
+    'detail_shared_of_property_message',
+    'site_visit_schedule_reminder',
+    'site_visit_schedule_after_visit',
+    'other'
+]
+```
+
+#### Default Computed Field Values:
+
+```python
+# On creation, all funnel metrics default to False
+is_delivered = False
+is_read = False
+has_replied = False
+```
+
+---
+
+### 3. `test_lead_scoring_events.py` - Event Relationships
+
+**Class:** `TestLeadScoringEvents(LeadScoringTestCase)`  
+**Model Under Test:** `lead.scoring.event`  
+**Total Tests:** 3
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_event_one2many_relationship` | Lead access to events |
+| 02 | `test_02_events_isolated_per_lead` | Event isolation per lead |
+| 03 | `test_03_event_cascade_delete` | Cascade delete on lead removal |
+
+#### Relationship Diagram:
+
+```
+lead.scoring.lead (1) ──────────< (∞) lead.scoring.event
+       │                                    │
+       │ event_ids (One2many)               │
+       └────────────────────────────────────┘
+                                 lead_id (Many2one)
+
+ON DELETE: CASCADE (events deleted with lead)
+```
+
+---
+
+### 4. `test_lead_scoring_funnel.py` - Funnel Metrics
+
+**Class:** `TestLeadScoringFunnel(LeadScoringTestCase)`  
+**Model Under Test:** `lead.scoring.lead`  
+**Total Tests:** 8
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_initial_funnel_state` | All metrics False initially |
+| 02 | `test_02_is_delivered_on_delivered_event` | Delivered flag on status_delivered |
+| 03 | `test_03_is_delivered_on_read_event` | Delivered flag on status_read |
+| 04 | `test_04_is_read_on_read_event` | Read flag on status_read |
+| 05 | `test_05_is_read_not_set_on_delivered_event` | Read False if only delivered |
+| 06 | `test_06_has_replied_on_inbound_message` | Replied flag on inbound |
+| 07 | `test_07_last_response_captures_inbound_content` | Most recent reply content |
+| 08 | `test_08_last_response_false_when_no_replies` | False when no inbound |
+
+#### Funnel Metric Logic:
+
+```
+Message Flow:
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│  message_sent   │ -> │ status_delivered│ -> │   status_read   │
+│                 │    │ is_delivered=✓  │    │ is_delivered=✓  │
+│                 │    │                 │    │ is_read=✓       │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+
+Customer Reply:
+┌─────────────────┐
+│message_received │ -> has_replied=✓, last_response="content"
+│   (inbound)     │
+└─────────────────┘
+```
+
+---
+
+### 5. `test_lead_scoring_metrics.py` - Message Count Metrics
+
+**Class:** `TestLeadScoringMetrics(LeadScoringTestCase)`  
+**Model Under Test:** `lead.scoring.lead`  
+**Total Tests:** 8
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_initial_counts_zero` | All counts zero initially |
+| 02 | `test_02_total_outbound_counts_unique_messages` | Unique outbound count |
+| 03 | `test_03_total_outbound_ignores_status_events` | Exclude status events |
+| 04 | `test_04_total_outbound_deduplicates_same_correlation` | Deduplicate by correlation_id |
+| 05 | `test_05_total_inbound_counts_all_replies` | All inbound messages |
+| 06 | `test_06_total_failed_counts_unique_failures` | Unique failed count |
+| 07 | `test_07_total_failed_deduplicates_same_correlation` | Deduplicate failures |
+| 08 | `test_08_last_activity_tracks_most_recent_event` | Latest event timestamp |
+
+#### Count Metrics Logic:
+
+```python
+# total_outbound: Unique correlation_ids for message_sent events
+# Excludes: status_delivered, status_read, status_failed
+
+# total_inbound: All inbound message_received events
+# No deduplication (each reply counted)
+
+# total_failed: Unique correlation_ids for status_failed events
+# Deduplicated by correlation_id
+```
+
+---
+
+### 6. `test_lead_scoring_template_counts.py` - Template Tracking
+
+**Class:** `TestLeadScoringTemplateCounts(LeadScoringTestCase)`  
+**Model Under Test:** `lead.scoring.lead`  
+**Total Tests:** 10
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_all_template_counts_initially_zero` | All counts zero |
+| 02 | `test_02_cnt_ringing_counts_ringing_template` | Ringing template count |
+| 03 | `test_03_cnt_details_counts_detail_shared_template` | Details template count |
+| 04 | `test_04_cnt_visit_reminder_counts_reminder_template` | Visit reminder count |
+| 05 | `test_05_cnt_visit_feedback_counts_feedback_template` | Visit feedback count |
+| 06 | `test_06_response_templates_counted_separately` | Response template isolation |
+| 07 | `test_07_template_counts_deduplicate_by_correlation` | Correlation deduplication |
+| 08 | `test_08_template_counts_ignore_non_template_events` | Ignore null templates |
+| 09 | `test_09_template_counts_only_outbound` | Outbound only |
+| 10 | `test_10_multiple_templates_counted_independently` | Independent template counts |
+
+#### Template Count Fields:
+
+| Field | Template Name |
+|-------|---------------|
+| `cnt_ringing` | `ringing` |
+| `cnt_details` | `detail_shared_of_property_message` |
+| `cnt_visit_reminder` | `site_visit_schedule_reminder` |
+| `cnt_visit_feedback` | `site_visit_schedule_after_visit` |
+| `cnt_resp_going_visit` | `going_for_visit_today` |
+| `cnt_resp_need_help` | `need_help_for_site_visit_today` |
+| `cnt_resp_visit_done` | `visit_done_response_after_site_visit` |
+| `cnt_resp_abhi_call` | `ringing_abhi_call_kare` |
+
+---
+
+### 7. `test_lead_scoring_smart_buttons.py` - UI Actions
+
+**Class:** `TestLeadScoringSmartButtons(LeadScoringTestCase)`  
+**Model Under Test:** `lead.scoring.lead`  
+**Total Tests:** 4
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_action_view_events_returns_outbound_domain` | Events button action |
+| 02 | `test_02_action_view_replies_returns_inbound_domain` | Replies button action |
+| 03 | `test_03_action_view_failures_returns_failed_domain` | Failures button action |
+| 04 | `test_04_smart_button_actions_have_default_context` | Context with default_lead_id |
+
+#### Smart Button Action Structure:
+
+```python
+# action_view_events()
+{
+    'type': 'ir.actions.act_window',
+    'res_model': 'lead.scoring.event',
+    'view_mode': 'list,form',
+    'domain': [
+        ('lead_id', '=', lead.id),
+        ('message_direction', '=', 'outbound')
+    ],
+    'context': {'default_lead_id': lead.id}
+}
+
+# action_view_replies()
+{
+    'type': 'ir.actions.act_window',
+    'res_model': 'lead.scoring.event',
+    'domain': [
+        ('lead_id', '=', lead.id),
+        ('message_direction', '=', 'inbound')
+    ],
+    'context': {'default_lead_id': lead.id}
+}
+
+# action_view_failures()
+{
+    'type': 'ir.actions.act_window',
+    'res_model': 'lead.scoring.event',
+    'domain': [
+        ('lead_id', '=', lead.id),
+        ('event_type', '=', 'status_failed')
+    ],
+    'context': {'default_lead_id': lead.id}
+}
+```
+
+---
+
+## Test Coverage Matrix
+
+| Feature | CRUD | Compute | Validation | Relationship | UI Actions |
+|---------|:----:|:-------:|:----------:|:------------:|:----------:|
+| Lead Creation | ✅ | | ✅ | | |
+| Phone Uniqueness | | | ✅ | | |
+| Event Tracking | ✅ | | | ✅ | |
+| Funnel Metrics | | ✅ | | | |
+| Message Counts | | ✅ | | | |
+| Template Counts | | ✅ | | | |
+| Last Activity | | ✅ | | | |
+| Smart Buttons | | | | | ✅ |
+| Cascade Delete | | | | ✅ | |
+
+---
+
+## Common Test Fixtures
+
+### Creating Unique Test Data
+
+```python
+# The helper automatically generates unique phones
+lead = self.create_lead()  # Phone auto-generated
+
+# Override specific phone if needed
+lead = self.create_lead(lead_phone='9876543210')
+```
+
+### Event Creation Patterns
+
+```python
+# Full message flow: sent -> delivered -> read
+corr_id = 'corr_123'
+
+self.create_outbound_sent_event(lead, 'ringing', correlation_id=corr_id)
+self.create_status_event(lead, 'status_delivered', corr_id)
+self.create_status_event(lead, 'status_read', corr_id)
+
+# Customer reply
+self.create_inbound_event(lead, 'Yes, interested')
+```
+
+### Testing Database Constraints
+
+```python
+from odoo.tools import mute_logger
+from psycopg2 import IntegrityError
+
+# Test NOT NULL constraint
+with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
+    self.env['lead.scoring.lead'].create({
+        'lead_name': 'Test',
+        # Missing 'lead_phone' triggers IntegrityError
+    })
+
+# Test UNIQUE constraint
+with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
+    self.create_lead(lead_phone='9876543210')  # Already exists
+```
+
+### Cache Invalidation
+
+```python
+# After creating events, invalidate computed fields
+lead.invalidate_recordset()
+
+# Or specific fields
+lead.invalidate_recordset(['is_delivered', 'is_read', 'total_outbound'])
+```
+
+---
+
+## Template System
+
+### Trigger Templates (Outbound)
+
+```python
+TEMPLATE_TRIGGERS = [
+    'ringing',                           # Initial contact
+    'detail_shared_of_property_message', # Property details
+    'site_visit_schedule_reminder',      # Visit reminder
+    'site_visit_schedule_after_visit'    # Post-visit follow-up
+]
+```
+
+### Response Templates
+
+```python
+TEMPLATE_RESPONSES = [
+    'going_for_visit_today',
+    'need_help_for_site_visit_today',
+    'visit_done_response_after_site_visit',
+    'liked_property_after_site_visit',
+    'call_the_expert_after_site_vist',
+    'reschedule_visit_response',
+    'ringing_abhi_call_kare',
+    'ringing_slot_book_kare',
+    'schedule_visit_now_response',
+    'talk_to_a_property_expert_response'
+]
+```
+
+### Event Types
+
+| Event Type | Description | Direction |
+|------------|-------------|-----------|
+| `message_sent` | Initial message send | Outbound |
+| `status_sent` | Send confirmation | Outbound |
+| `status_delivered` | Delivery confirmation | Outbound |
+| `status_read` | Read receipt | Outbound |
+| `status_failed` | Delivery failure | Outbound |
+| `message_received` | Customer reply | Inbound |
+
+### Correlation ID Usage
+
+```
+correlation_id links related events:
+
+message_sent (corr_001) ─┬─> status_delivered (corr_001)
+                         └─> status_read (corr_001)
+
+Deduplication: Counts use DISTINCT correlation_id
+```
+
+---
+
+## Best Practices
+
+### 1. Use Helper Methods
+
+```python
+# ✅ Good - Uses helper with auto-unique phone
+lead = self.create_lead()
+
+# ❌ Bad - Manual creation without unique phone handling
+lead = self.env['lead.scoring.lead'].create({...})
+```
+
+### 2. Track Correlation IDs
+
+```python
+# ✅ Good - Explicit correlation_id for related events
+corr_id = 'corr_unique_123'
+self.create_outbound_sent_event(lead, 'ringing', correlation_id=corr_id)
+self.create_status_event(lead, 'status_delivered', corr_id)
+
+# ❌ Bad - Auto-generated correlation_ids (can't link events)
+self.create_outbound_sent_event(lead, 'ringing')
+self.create_status_event(lead, 'status_delivered', 'different_corr')
+```
+
+### 3. Invalidate Cache After Event Creation
+
+```python
+# Create events
+self.create_outbound_sent_event(lead, 'ringing', 'corr_1')
+self.create_status_event(lead, 'status_delivered', 'corr_1')
+
+# ✅ Good - Invalidate before assertions
+lead.invalidate_recordset()
+self.assertTrue(lead.is_delivered)
+
+# ❌ Bad - Stale cache may cause false assertions
+self.assertTrue(lead.is_delivered)  # May be False from cache
+```
+
+### 4. Test Naming Convention
+
+```
+test_{order}_{description}
+
+Examples:
+- test_01_create_lead_with_required_fields
+- test_02_lead_phone_required
+- test_03_unique_phone_constraint
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. IntegrityError Not Raised
+
+```python
+# Ensure mute_logger is used
+from odoo.tools import mute_logger
+from psycopg2 import IntegrityError
+
+with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
+    # Code that should raise
+```
+
+#### 2. Computed Field Not Updating
+
+```python
+# Force cache invalidation
+lead.invalidate_recordset()
+
+# For specific fields
+lead.invalidate_recordset(['is_delivered', 'total_outbound'])
+
+# Or flush and invalidate
+self.env.flush_all()
+lead.invalidate_recordset()
+```
+
+#### 3. Duplicate Phone Errors in Tests
+
+```python
+# Use the helper - it auto-generates unique phones
+lead = self.create_lead()  # ✅ Safe
+
+# If manually specifying phone, ensure uniqueness
+unique_phone = f'99{int(time.time())}_{random.randint(100,999)}'[-10:]
+lead = self.create_lead(lead_phone=unique_phone)
+```
+
+#### 4. Event Order Issues
+
+```python
+# Events may not be in expected order - use timestamps
+from datetime import datetime, timedelta
+
+old_time = datetime.now() - timedelta(hours=2)
+new_time = datetime.now()
+
+self.create_event(lead=lead, event_timestamp=old_time)
+self.create_event(lead=lead, event_timestamp=new_time)
+
+lead.invalidate_recordset(['last_activity'])
+# last_activity should be new_time
+```
+
+#### 5. Template Count Not Incrementing
+
+```python
+# Ensure template_name matches exactly
+self.create_outbound_sent_event(lead, 'ringing', 'corr_1')  # ✅
+
+# Wrong template name (typo)
+self.create_outbound_sent_event(lead, 'Ringing', 'corr_1')  # ❌ Case sensitive
+
+# Ensure it's outbound (inbound events don't count for templates)
+self.create_event(
+    lead=lead,
+    message_direction='outbound',  # ✅ Required
+    template_name='ringing',
+    ...
+)
+```
+
+---
+
+## Contributing
+
+When adding new tests:
+
+1. Follow existing naming conventions
+2. Inherit from `LeadScoringTestCase`
+3. Use `@tagged('post_install', '-at_install')` decorator
+4. Add test import to `__init__.py`
+5. Update this README with new test documentation
+6. Use helper methods for data creation
+7. Always invalidate cache before assertions on computed fields
+8. Use explicit correlation_ids for related events
+
+---
+
+## License
+
+This test suite is part of the ClearDeals Dashboards module and follows the same licensing as the parent Odoo project.
+
+---
+
+*Last Updated: January 2026*  
+*Odoo Version: 19.0*

--- a/custom_addons/lead_suggestor/tests/README.md
+++ b/custom_addons/lead_suggestor/tests/README.md
@@ -1,0 +1,734 @@
+# Lead Suggestor Module - Test Suite Documentation
+
+> **Odoo 19 Custom Module Testing Documentation**  
+> **Module:** `lead_suggestor`  
+> **Path:** `/custom_addons/lead_suggestor/tests/`
+
+---
+
+## 📋 Table of Contents
+
+1. [Overview](#overview)
+2. [Test Architecture](#test-architecture)
+3. [Running Tests](#running-tests)
+4. [Test Files Reference](#test-files-reference)
+5. [Test Coverage Matrix](#test-coverage-matrix)
+6. [Common Test Fixtures](#common-test-fixtures)
+7. [Mocking BigQuery](#mocking-bigquery)
+8. [Best Practices](#best-practices)
+9. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+This test suite provides comprehensive coverage for the **Lead Suggestor Module** in Odoo 19. The module enables property-based lead suggestions using BigQuery integration for ML-driven recommendations.
+
+### Models Under Test
+
+| Model | Description |
+|-------|-------------|
+| `property.inventory` | Property listings with portal IDs, RM assignments, and service dates |
+| `property.lead.suggestion` | ML-generated lead suggestions linked to properties |
+
+### Test Statistics
+
+- **Total Test Files:** 11
+- **Test Categories:** CRUD, Dates, Counts, WhatsApp, Feedback, Cron Jobs, Integration
+- **External Dependencies:** Google BigQuery (mocked in tests)
+- **Test Tags:** `@tagged('post_install', '-at_install')`
+
+---
+
+## Test Architecture
+
+```
+tests/
+├── __init__.py                       # Test module imports
+├── test_property_common.py           # Base test fixtures (PropertyInventoryTestCase)
+│
+├── Property Inventory Tests
+│   ├── test_property_inventory_crud.py   # CRUD operations (8 tests)
+│   ├── test_property_inventory_dates.py  # Date formatting (7 tests)
+│   └── test_property_inventory_cron.py   # Cron jobs (6 tests)
+│
+├── Suggestion Tests
+│   ├── test_suggestion_crud.py           # CRUD operations (9 tests)
+│   ├── test_suggestion_counts.py         # Count computations (5 tests)
+│   ├── test_suggestion_whatsapp.py       # WhatsApp integration (12 tests)
+│   ├── test_suggestion_feedback.py       # Feedback logging (4 tests)
+│   ├── test_suggestion_cron.py           # BigQuery sync (5 tests)
+│   └── test_suggestion_dates.py          # Date formatting (4 tests)
+│
+├── test_integration.py               # Cross-model integration (3 tests)
+└── README.md                         # This documentation
+```
+
+---
+
+## Running Tests
+
+### Run All Lead Suggestor Module Tests
+
+```bash
+# Windows (from project root)
+python odoo-bin -c odoo.conf -d <database_name> --test-enable --stop-after-init -i lead_suggestor
+
+# With specific log level
+python odoo-bin -c odoo.conf -d <database_name> --test-enable --stop-after-init -i lead_suggestor --log-level=test
+```
+
+### Run Specific Test File
+
+```bash
+# Run only suggestion CRUD tests
+python odoo-bin -c odoo.conf -d <database_name> --test-enable --stop-after-init --test-file=custom_addons/lead_suggestor/tests/test_suggestion_crud.py
+```
+
+### Run Tests by Tag
+
+```bash
+# Run post_install tests only
+python odoo-bin -c odoo.conf -d <database_name> --test-tags=post_install
+```
+
+### Using pytest-odoo (Alternative)
+
+```bash
+pytest custom_addons/lead_suggestor/tests/ -v --odoo-database=<database_name>
+```
+
+---
+
+## Test Files Reference
+
+### 1. `test_property_common.py` - Base Test Fixtures
+
+**Purpose:** Provides the `PropertyInventoryTestCase` base class with shared fixtures for all tests.
+
+#### Fixtures Created:
+
+| Fixture | Type | Description |
+|---------|------|-------------|
+| `cls.rm_user` | `res.users` | Primary test Relationship Manager |
+| `cls.rm_user2` | `res.users` | Secondary RM for assignment tests |
+| `cls.timestamp` | `str` | Unique identifier for test isolation |
+
+#### Helper Methods:
+
+```python
+def create_property(self, **kwargs):
+    """
+    Create Property Inventory with sensible defaults.
+    
+    Default Values:
+        - property_tag: Unique auto-generated tag
+        - rm_user_id: cls.rm_user.id
+        - is_active: True
+        - service_expiry_date: today + 30 days
+        - welcome_call_date: today
+        - bhk: '3 BHK'
+        - location: 'Test Location'
+        - city: 'Test City'
+    
+    Returns:
+        property.inventory: Created property record
+    """
+
+def create_suggestion(self, property_rec=None, **kwargs):
+    """
+    Create a Lead Suggestion with sensible defaults.
+    
+    Args:
+        property_rec: Optional property record (creates one if None)
+        **kwargs: Override any default field values
+    
+    Default Values:
+        - suggested_lead_phone: Unique auto-generated phone
+        - lead_name: 'Test Lead'
+        - original_property_tag: 'OLD-PROP-001'
+        - original_property_similarity: 85.0
+        - generation_date: today
+        - contact_type: 'New'
+        - status: 'new'
+    
+    Returns:
+        property.lead.suggestion: Created suggestion record
+    """
+```
+
+---
+
+### 2. `test_property_inventory_crud.py` - Property CRUD Operations
+
+**Class:** `TestPropertyInventoryCRUD(PropertyInventoryTestCase)`  
+**Model Under Test:** `property.inventory`  
+**Total Tests:** 8
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_create_property_with_required_fields` | Basic property creation |
+| 02 | `test_02_property_tag_required` | DB constraint for property_tag |
+| 03 | `test_03_property_tag_unique_constraint` | Unique tag enforcement |
+| 04 | `test_04_default_is_active` | Default active status |
+| 05 | `test_05_rm_user_assignment` | RM user linkage |
+| 06 | `test_06_optional_fields_storage` | Optional field persistence |
+| 07 | `test_07_portal_ids_storage` | Portal ID storage |
+| 08 | `test_08_property_ordering` | Order by service_expiry_date asc |
+
+#### Portal IDs Tested:
+
+```python
+# All portal IDs stored in test_07
+- magicbricks_id: 'MB12345'
+- housing_id: 'HSG67890'
+- ninety_nine_acres_id: '99ACR11223'
+- olx_id: 'OLX44556'
+```
+
+---
+
+### 3. `test_property_inventory_dates.py` - Property Date Handling
+
+**Class:** `TestPropertyInventoryDates(PropertyInventoryTestCase)`  
+**Model Under Test:** `property.inventory`  
+**Total Tests:** 7
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_service_expiry_date_storage` | Date field storage |
+| 02 | `test_02_welcome_call_date_storage` | Welcome call date |
+| 03 | `test_03_service_expiry_display_format` | DD/MM/YYYY format |
+| 04 | `test_04_welcome_call_display_format` | DD/MM/YYYY format |
+| 05 | `test_05_date_display_with_leading_zeros` | Leading zeros in dates |
+| 06 | `test_06_empty_date_display` | Empty string for null dates |
+| 07 | `test_07_date_recompute_on_change` | Display recomputation |
+
+#### Date Display Format:
+
+```
+Input: date(2026, 3, 14)
+Output: '14/03/2026'  (DD/MM/YYYY)
+
+Input: date(2026, 1, 5)
+Output: '05/01/2026'  (with leading zeros)
+
+Input: False/None
+Output: ''  (empty string)
+```
+
+---
+
+### 4. `test_property_inventory_cron.py` - Property Cron Jobs
+
+**Class:** `TestPropertyInventoryCron(PropertyInventoryTestCase)`  
+**Model Under Test:** `property.inventory`  
+**Total Tests:** 6
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_cleanup_marks_expired_properties_inactive` | Deactivate expired |
+| 02 | `test_02_cleanup_keeps_active_properties_active` | Keep future-expiry active |
+| 03 | `test_03_cleanup_handles_multiple_expired` | Batch expired handling |
+| 04 | `test_04_cleanup_skips_already_inactive` | Skip inactive properties |
+| 05 | `test_05_cleanup_boundary_today` | Today's expiry = active |
+| 06 | `test_06_sync_properties_handles_bigquery_error` | BQ error handling |
+
+#### Cron Method: `_cron_cleanup_expired_properties`
+
+```
+Expiry Logic:
+├── service_expiry_date < today → is_active = False
+├── service_expiry_date = today → remains active
+└── service_expiry_date > today → remains active
+```
+
+---
+
+### 5. `test_suggestion_crud.py` - Suggestion CRUD Operations
+
+**Class:** `TestSuggestionCRUD(PropertyInventoryTestCase)`  
+**Model Under Test:** `property.lead.suggestion`  
+**Total Tests:** 9
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_create_suggestion_with_required_fields` | Basic creation |
+| 02 | `test_02_suggestion_requires_property` | Property FK required |
+| 03 | `test_03_suggestion_requires_phone` | Phone field required |
+| 04 | `test_04_unique_constraint_property_phone` | Unique per property |
+| 05 | `test_05_same_phone_different_properties_allowed` | Cross-property allowed |
+| 06 | `test_06_property_tag_related_field` | Related field access |
+| 07 | `test_07_default_status_new` | Default 'new' status |
+| 08 | `test_08_status_field_values` | Valid status values |
+| 09 | `test_09_suggestion_ordering` | Order by date desc |
+
+#### Valid Status Values:
+
+```python
+[
+    'new',
+    'contacted', 
+    'details_shared_of_property',
+    'not_interested',
+    'interested',
+    'converted',
+    'whatsapp_done',
+    'other'
+]
+```
+
+#### Unique Constraint:
+
+```
+UNIQUE(property_inventory_id, suggested_lead_phone)
+
+✅ Allowed: Same phone for DIFFERENT properties
+❌ Blocked: Same phone for SAME property
+```
+
+---
+
+### 6. `test_suggestion_counts.py` - Count Computations
+
+**Class:** `TestSuggestionCounts(PropertyInventoryTestCase)`  
+**Model Under Test:** `property.inventory` (computed fields)  
+**Total Tests:** 5
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_initial_counts_zero` | Zero counts on new property |
+| 02 | `test_02_total_count_increases` | Total count increments |
+| 03 | `test_03_new_count_only_counts_new_status` | Filter by 'new' status |
+| 04 | `test_04_counts_update_on_status_change` | Dynamic count updates |
+| 05 | `test_05_multiple_properties_independent_counts` | Property isolation |
+
+#### Computed Fields:
+
+| Field | Description |
+|-------|-------------|
+| `suggestion_count` | Total suggestions linked to property |
+| `new_suggestion_count` | Suggestions with status='new' only |
+
+---
+
+### 7. `test_suggestion_whatsapp.py` - WhatsApp Integration
+
+**Class:** `TestSuggestionWhatsapp(PropertyInventoryTestCase)`  
+**Model Under Test:** `property.lead.suggestion`  
+**Total Tests:** 12
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_whatsapp_url_10_digit_phone` | Standard 10-digit phone |
+| 02 | `test_02_whatsapp_url_with_91_prefix` | Handle 91 prefix |
+| 03 | `test_03_whatsapp_url_with_leading_zero` | Strip leading zero |
+| 04 | `test_04_whatsapp_url_with_spaces_dashes` | Clean special chars |
+| 05 | `test_05_whatsapp_url_with_plus_sign` | Handle +91 prefix |
+| 06 | `test_06_whatsapp_url_invalid_phone` | Invalid = False |
+| 07 | `test_07_whatsapp_url_empty_phone` | Empty = False |
+| 08 | `test_08_whatsapp_html_contains_icon` | fa-whatsapp icon |
+| 09 | `test_09_whatsapp_html_no_url_shows_plain_phone` | Fallback display |
+| 10 | `test_10_action_whatsapp_returns_client_action` | Client action type |
+| 11 | `test_11_action_whatsapp_message_contains_details` | Message content |
+| 12 | `test_12_action_whatsapp_uses_first_name_only` | First name extraction |
+
+#### Phone Standardization Examples:
+
+| Input | Output URL Contains |
+|-------|---------------------|
+| `9876543210` | `phone=919876543210` |
+| `919876543210` | `phone=919876543210` |
+| `09876543210` | `phone=919876543210` |
+| `98765-43210` | `phone=919876543210` |
+| `+919876543210` | `phone=919876543210` |
+| `INVALID` | `False` |
+| `` (empty) | `False` |
+
+#### WhatsApp Action Structure:
+
+```python
+{
+    'type': 'ir.actions.client',
+    'tag': 'whatsapp_with_copy',
+    'context': {
+        'whatsapp_url': 'whatsapp://send?phone=91...',
+        'message_text': 'Hi {name}, ...'  # Contains BHK, location, city, link
+    }
+}
+```
+
+---
+
+### 8. `test_suggestion_feedback.py` - Feedback Logging
+
+**Class:** `TestSuggestionFeedback(PropertyInventoryTestCase)`  
+**Model Under Test:** `property.lead.suggestion`  
+**Total Tests:** 4
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_action_log_feedback_returns_wizard` | Returns wizard action |
+| 02 | `test_02_action_log_feedback_passes_context` | Context with defaults |
+| 03 | `test_03_rm_feedback_field_storage` | Feedback text storage |
+| 04 | `test_04_status_transitions` | Status can be changed |
+
+#### Feedback Wizard Action:
+
+```python
+{
+    'type': 'ir.actions.act_window',
+    'res_model': 'suggestion.feedback.wizard',
+    'view_mode': 'form',
+    'target': 'new',
+    'context': {
+        'default_suggestion_id': suggestion.id,
+        'default_status': 'contacted',
+        'default_rm_feedback': 'Initial contact made'
+    }
+}
+```
+
+---
+
+### 9. `test_suggestion_cron.py` - BigQuery Sync Cron
+
+**Class:** `TestSuggestionCron(PropertyInventoryTestCase)`  
+**Model Under Test:** `property.lead.suggestion`  
+**Total Tests:** 5
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_cron_sync_creates_new_suggestions` | Create from BQ data |
+| 02 | `test_02_cron_sync_skips_duplicates` | Skip existing phone+property |
+| 03 | `test_03_cron_sync_skips_unknown_properties` | Skip non-existent properties |
+| 04 | `test_04_cron_sync_handles_multiple_suggestions` | Batch creation |
+| 05 | `test_05_cron_sync_handles_bigquery_error` | Graceful error handling |
+
+#### BigQuery Mock Structure:
+
+```python
+from collections import namedtuple
+
+BQRow = namedtuple('Row', [
+    'active_property_tag',
+    'suggested_lead_phone',
+    'lead_name',
+    'original_property_tag',
+    'original_property_similarity',
+    'generation_date',
+    'current_status'
+])
+```
+
+---
+
+### 10. `test_suggestion_dates.py` - Suggestion Date Handling
+
+**Class:** `TestSuggestionDates(PropertyInventoryTestCase)`  
+**Model Under Test:** `property.lead.suggestion`  
+**Total Tests:** 4
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_generation_date_default_today` | Default to today |
+| 02 | `test_02_generation_date_display_format` | DD/MM/YYYY format |
+| 03 | `test_03_generation_date_display_with_zeros` | Leading zeros |
+| 04 | `test_04_generation_date_recompute` | Recompute on change |
+
+---
+
+### 11. `test_integration.py` - Cross-Model Integration
+
+**Class:** `TestPropertySuggestionIntegration(PropertyInventoryTestCase)`  
+**Models Under Test:** `property.inventory`, `property.lead.suggestion`  
+**Total Tests:** 3
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_property_cascade_delete_suggestions` | Cascade delete |
+| 02 | `test_02_suggestion_one2many_relationship` | One2many access |
+| 03 | `test_03_multiple_properties_suggestion_isolation` | Data isolation |
+
+#### Relationship Diagram:
+
+```
+property.inventory (1) ──────────< (∞) property.lead.suggestion
+       │                                        │
+       │ suggestion_ids (One2many)              │
+       └────────────────────────────────────────┘
+                                     property_inventory_id (Many2one)
+
+ON DELETE: CASCADE (suggestions deleted with property)
+```
+
+---
+
+## Test Coverage Matrix
+
+| Feature | CRUD | Compute | Validation | Cron | Integration |
+|---------|:----:|:-------:|:----------:|:----:|:-----------:|
+| Property Creation | ✅ | | ✅ | | |
+| Property Tags | ✅ | | ✅ | | |
+| Portal IDs | ✅ | | | | |
+| Date Formatting | | ✅ | | | |
+| Service Expiry | | ✅ | | ✅ | |
+| Suggestion Creation | ✅ | | ✅ | | |
+| Unique Constraints | | | ✅ | | |
+| Suggestion Counts | | ✅ | | | |
+| WhatsApp URLs | | ✅ | | | |
+| WhatsApp Messages | | ✅ | | | |
+| Feedback Wizard | ✅ | | | | |
+| BigQuery Sync | | | | ✅ | ✅ |
+| Cascade Delete | | | | | ✅ |
+
+---
+
+## Common Test Fixtures
+
+### Creating Unique Test Data
+
+```python
+import time
+import random
+
+# Unique suffix for test isolation
+unique_suffix = f"{int(time.time() * 100000)}_{random.randint(1000, 9999)}"
+
+# Unique phone number
+unique_phone = f'9{unique_suffix[-9:]}'
+
+# Unique property tag
+property_tag = f'TEST-PROP-{unique_suffix}'
+```
+
+### Testing Database Constraints
+
+```python
+from odoo.tools import mute_logger
+import psycopg2
+
+# Test NOT NULL constraint
+with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.IntegrityError):
+    self.env['property.inventory'].create({
+        'is_active': True,
+        # Missing 'property_tag' triggers IntegrityError
+    })
+
+# Test UNIQUE constraint
+with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.IntegrityError):
+    self.create_property(property_tag='DUPLICATE-TAG')  # Already exists
+```
+
+### Cache Invalidation
+
+```python
+# Invalidate specific field
+prop.invalidate_recordset(['suggestion_count'])
+
+# Invalidate all fields
+prop.invalidate_recordset()
+```
+
+---
+
+## Mocking BigQuery
+
+### Basic Setup
+
+```python
+from unittest.mock import patch, MagicMock
+
+@patch('google.cloud.bigquery.Client')
+def test_bigquery_sync(self, mock_bq_client):
+    # Create mock instance
+    mock_instance = mock_bq_client.return_value
+    mock_query_job = MagicMock()
+    mock_instance.query.return_value = mock_query_job
+    
+    # Define row structure
+    from collections import namedtuple
+    BQRow = namedtuple('Row', [
+        'active_property_tag',
+        'suggested_lead_phone',
+        'lead_name',
+        'original_property_tag',
+        'original_property_similarity',
+        'generation_date',
+        'current_status'
+    ])
+    
+    # Create mock data
+    mock_rows = [
+        BQRow(
+            active_property_tag='PROP-001',
+            suggested_lead_phone='9876543210',
+            lead_name='Test Lead',
+            original_property_tag='OLD-PROP',
+            original_property_similarity=0.85,
+            generation_date=date.today(),
+            current_status='New'
+        )
+    ]
+    
+    mock_query_job.result.return_value = mock_rows
+    
+    # Run the method
+    self.env['property.lead.suggestion']._cron_sync_suggestions()
+```
+
+### Mocking Errors
+
+```python
+@patch('google.cloud.bigquery.Client')
+def test_bigquery_error_handling(self, mock_bq_client):
+    # Simulate connection error
+    mock_bq_client.side_effect = Exception("BigQuery connection failed")
+    
+    # Should not raise - handles gracefully
+    try:
+        self.env['property.lead.suggestion']._cron_sync_suggestions()
+    except Exception as e:
+        self.fail(f"Should handle BQ errors gracefully: {e}")
+```
+
+---
+
+## Best Practices
+
+### 1. Test Independence
+
+Each test should be independent:
+
+```python
+def setUp(self):
+    super().setUp()
+    self.property = self.create_property()  # Fresh data each test
+```
+
+### 2. Use High-Resolution Unique IDs
+
+```python
+# ✅ Good - High resolution + random
+unique_suffix = f"{int(time.time() * 100000)}_{random.randint(1000, 9999)}"
+
+# ❌ Bad - May collide in fast tests
+unique_suffix = str(int(time.time()))
+```
+
+### 3. Test Naming Convention
+
+```
+test_{order}_{description}
+
+Examples:
+- test_01_create_property_with_required_fields
+- test_02_property_tag_required
+- test_03_property_tag_unique_constraint
+```
+
+### 4. Always Invalidate Cache After Status Changes
+
+```python
+suggestion.status = 'contacted'
+prop.invalidate_recordset(['new_suggestion_count'])  # Recompute
+```
+
+### 5. Group Related Assertions
+
+```python
+# ✅ Good - Clear grouping
+self.assertEqual(prop.suggestion_count, 4)
+self.assertEqual(prop.new_suggestion_count, 2)
+
+# ❌ Bad - Mixed concerns
+self.assertTrue(prop.id)
+self.assertEqual(prop.suggestion_count, 4)
+self.assertEqual(prop.property_tag, 'TAG')
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. IntegrityError Not Raised
+
+```python
+# Ensure you're using mute_logger to suppress expected errors
+from odoo.tools import mute_logger
+import psycopg2
+
+with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.IntegrityError):
+    # Code that should raise
+```
+
+#### 2. Computed Field Not Updating
+
+```python
+# Force recomputation
+record.invalidate_recordset(['computed_field'])
+
+# Or invalidate all
+record.invalidate_recordset()
+```
+
+#### 3. BigQuery Mock Not Working
+
+```python
+# Ensure you're patching the correct import path
+@patch('google.cloud.bigquery.Client')  # ✅ Correct
+
+# NOT the method path
+@patch('odoo.addons.lead_suggestor.models.property.bigquery.Client')  # May not work
+```
+
+#### 4. Unique Constraint Violations in Tests
+
+```python
+# Use high-resolution unique identifiers
+unique_suffix = f"{int(time.time() * 100000)}_{random.randint(1000, 9999)}"
+
+# NOT just timestamp (can collide in fast tests)
+unique_suffix = str(int(time.time()))  # ❌
+```
+
+#### 5. Tests Not Isolated
+
+```python
+# Always create fresh data in setUp or test method
+def setUp(self):
+    super().setUp()
+    self.prop = self.create_property()  # Fresh each test
+
+# DON'T rely on class-level data for mutable state
+@classmethod
+def setUpClass(cls):
+    # Only for truly immutable fixtures (users, etc.)
+```
+
+---
+
+## Contributing
+
+When adding new tests:
+
+1. Follow existing naming conventions
+2. Inherit from `PropertyInventoryTestCase`
+3. Use `@tagged('post_install', '-at_install')` decorator
+4. Add test import to `__init__.py`
+5. Update this README with new test documentation
+6. Mock external dependencies (BigQuery, APIs)
+7. Use unique identifiers to prevent test pollution
+
+---
+
+## License
+
+This test suite is part of the Lead Suggestor module and follows the same licensing as the parent Odoo project.
+
+---
+
+*Last Updated: January 2026*  
+*Odoo Version: 19.0*

--- a/custom_addons/leads/models/new_portal_leads.py
+++ b/custom_addons/leads/models/new_portal_leads.py
@@ -59,6 +59,10 @@ class NewPortalLead(models.Model):
 
     remarks = fields.Text('Remarks')
 
+    is_ops_sale_lead = fields.Boolean(
+        string="Is Ops Sale Lead",
+        default=False)
+
     site_visit_date = fields.Datetime(
         string="Site Visit Scheduled On",
         copy = False,

--- a/custom_addons/leads/tests/README.md
+++ b/custom_addons/leads/tests/README.md
@@ -1,0 +1,556 @@
+# Leads Module - Test Suite Documentation
+
+> **Odoo 19 Custom Module Testing Documentation**  
+> **Module:** `leads`  
+> **Path:** `/custom_addons/leads/tests/`
+
+---
+
+## 📋 Table of Contents
+
+1. [Overview](#overview)
+2. [Test Architecture](#test-architecture)
+3. [Running Tests](#running-tests)
+4. [Test Files Reference](#test-files-reference)
+5. [Test Coverage Matrix](#test-coverage-matrix)
+6. [Common Test Fixtures](#common-test-fixtures)
+7. [Best Practices](#best-practices)
+8. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+This test suite provides comprehensive coverage for the **Leads Management Module** in Odoo 19. The tests cover two main models:
+
+| Model | Description |
+|-------|-------------|
+| `leads.new` | Portal leads from external sources (MagicBricks, Housing.com, 99acres, OLX) |
+| `lead.score` | Scored/processed leads with follow-up management |
+
+### Test Statistics
+
+- **Total Test Files:** 10
+- **Test Categories:** CRUD, Processing, API, Webhook, Cron Jobs, WhatsApp Integration
+- **Test Tags:** `@tagged('post_install', '-at_install')`
+
+---
+
+## Test Architecture
+
+```
+tests/
+├── __init__.py                      # Test module imports
+├── test_portal_common.py            # Base test fixtures (PortalLeadTestCase)
+├── test_lead_score.py               # Lead scoring model tests (20 tests)
+├── test_portal_lead_crud.py         # Basic CRUD operations (6 tests)
+├── test_portal_lead_duplicate.py    # Duplicate detection logic (5 tests)
+├── test_portal_lead_phone.py        # Phone standardization (9 tests)
+├── test_portal_lead_processing.py   # Lead assignment & property matching (10 tests)
+├── test_portal_lead_whatsapp.py     # WhatsApp URL generation (5 tests)
+├── test_portal_lead_cron.py         # Cron job operations (3 tests)
+├── test_portal_lead_api.py          # External API integrations (4 tests)
+├── test_portal_lead_webhook.py      # n8n webhook functionality (3 tests)
+└── README.md                        # This documentation
+```
+
+---
+
+## Running Tests
+
+### Run All Leads Module Tests
+
+```bash
+# Windows (from project root)
+python odoo-bin -c odoo.conf -d <database_name> --test-enable --stop-after-init -i leads
+
+# With specific log level
+python odoo-bin -c odoo.conf -d <database_name> --test-enable --stop-after-init -i leads --log-level=test
+```
+
+### Run Specific Test File
+
+```bash
+# Run only lead score tests
+python odoo-bin -c odoo.conf -d <database_name> --test-enable --stop-after-init --test-file=custom_addons/leads/tests/test_lead_score.py
+```
+
+### Run Tests by Tag
+
+```bash
+# Run post_install tests only
+python odoo-bin -c odoo.conf -d <database_name> --test-tags=post_install
+```
+
+### Using pytest-odoo (Alternative)
+
+```bash
+pytest custom_addons/leads/tests/ -v --odoo-database=<database_name>
+```
+
+---
+
+## Test Files Reference
+
+### 1. `test_portal_common.py` - Base Test Fixtures
+
+**Purpose:** Provides the `PortalLeadTestCase` base class with shared fixtures for all portal lead tests.
+
+#### Fixtures Created:
+
+| Fixture | Type | Description |
+|---------|------|-------------|
+| `cls.rm_user` | `res.users` | Test Relationship Manager user |
+| `cls.naresh_user` | `res.users` | Fallback user for unassigned leads |
+| `cls.test_property` | `property.inventory` | Test property with multiple portal IDs |
+| `cls.mb_id` | `str` | Dynamic MagicBricks property ID |
+| `cls.hsg_id` | `str` | Dynamic Housing.com property ID |
+| `cls.acres_id` | `str` | Dynamic 99acres property ID |
+| `cls.olx_id` | `str` | Dynamic OLX property ID |
+
+#### Helper Methods:
+
+```python
+def create_portal_lead(self, **kwargs):
+    """
+    Helper method to create portal leads with sensible defaults.
+    
+    Args:
+        **kwargs: Override any default field values
+        
+    Returns:
+        leads.new: Created lead record
+        
+    Example:
+        lead = self.create_portal_lead(
+            name='Custom Lead',
+            phone='9876543210',
+            portal_name='MagicBricks'
+        )
+    """
+```
+
+---
+
+### 2. `test_lead_score.py` - Lead Scoring Model Tests
+
+**Class:** `TestLeadScore(TransactionCase)`  
+**Model Under Test:** `lead.score`  
+**Total Tests:** 20
+
+#### Test Cases:
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_default_values` | Verify default values on creation |
+| 02 | `test_02_required_fields` | Enforce required fields (name) |
+| 03 | `test_03_actionable_flag_logic` | `is_actionable_today` computation |
+| 04 | `test_04_site_visit_follow_up_logic` | Auto follow-up date on site visit |
+| 05 | `test_05_rescheduled_follow_up_logic` | Follow-up on rescheduled status |
+| 06 | `test_06_site_visit_without_date` | Handle missing site visit date |
+| 07 | `test_07_onchange_status_behavior` | UI onchange follow-up update |
+| 08 | `test_08_onchange_does_not_affect_site_visit` | Onchange preserves site visit date |
+| 09 | `test_09_whatsapp_integration_count` | WhatsApp response counter |
+| 10 | `test_10_whatsapp_one2many_relationship` | One2many relationship integrity |
+| 11 | `test_11_cron_job_recomputation` | Cron recomputes actionable flag |
+| 12 | `test_12_cron_job_with_overdue_leads` | Batch overdue lead processing |
+| 13 | `test_13_multiple_status_changes` | Sequential status transitions |
+| 14 | `test_14_state_and_current_status_independence` | Field independence |
+| 15 | `test_15_lead_ordering` | Score-based ordering |
+| 16 | `test_16_feedback_fields_set_correctly` | Feedback field storage |
+| 17 | `test_17_edge_case_far_future_date` | Future date handling |
+| 18 | `test_18_edge_case_far_past_date` | Past date handling (overdue) |
+| 19 | `test_19_property_fields_storage` | Property data persistence |
+| 20 | `test_20_notes_field` | Notes field storage |
+
+#### Key Tested Logic:
+
+```python
+# Actionable Flag Logic (is_actionable_today)
+- True if: next_follow_up_date <= today OR next_follow_up_date is False
+- False if: next_follow_up_date > today
+
+# Site Visit Follow-up Logic
+- When current_status = 'site_visit_scheduled'
+- next_follow_up_date = site_visit_scheduled_date + 1 day
+```
+
+---
+
+### 3. `test_portal_lead_crud.py` - CRUD Operations
+
+**Class:** `TestPortalLeadCRUD(PortalLeadTestCase)`  
+**Model Under Test:** `leads.new`  
+**Total Tests:** 7
+
+| Test ID | Method | Description |
+|---------|--------|-----------|
+| 01 | `test_01_create_lead_with_required_fields` | Basic lead creation |
+| 02 | `test_02_missing_required_fields` | Required field validation |
+| 04 | `test_04_related_property_fields` | Property field propagation |
+| 05 | `test_05_compute_create_date_only` | Date computation |
+| 06 | `test_06_compute_site_visit_date_only` | Site visit date extraction |
+| 07 | `test_07_ops_sales_lead_flag` | OPS sales lead boolean flag |
+
+---
+
+### 4. `test_portal_lead_duplicate.py` - Duplicate Detection
+
+**Class:** `TestPortalLeadDuplicateDetection(PortalLeadTestCase)`  
+**Model Under Test:** `leads.new`  
+**Total Tests:** 5
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_no_duplicate_different_phone` | Different phones = not duplicate |
+| 02 | `test_02_no_duplicate_different_property` | Different property = not duplicate |
+| 03 | `test_03_duplicate_same_phone_and_property_recent` | Same phone + property + <30 days = duplicate |
+| 04 | `test_04_not_duplicate_after_30_days` | Same lead after 30 days allowed |
+| 05 | `test_05_duplicate_detection_log_message` | Logs message on existing lead |
+
+#### Duplicate Detection Rules:
+
+```
+DUPLICATE if ALL conditions met:
+├── Same phone number (standardized)
+├── Same portal_property_id
+└── Created within last 30 days
+
+NOT DUPLICATE if ANY:
+├── Different phone number
+├── Different portal_property_id
+└── More than 30 days old
+```
+
+---
+
+### 5. `test_portal_lead_phone.py` - Phone Standardization
+
+**Class:** `TestPortalLeadPhoneStandardization(PortalLeadTestCase)`  
+**Model Under Test:** `leads.new`  
+**Total Tests:** 9
+
+| Test ID | Input | Expected Output |
+|---------|-------|-----------------|
+| 01 | `9876543210` | `9876543210` |
+| 02 | `919876543210` | `9876543210` |
+| 03 | `98765 43210` | `9876543210` |
+| 04 | `98765-43210` | `9876543210` |
+| 05 | `+919876543210` | `9876543210` |
+| 06 | `(987) 654-3210` | `9876543210` |
+| 07 | `` (empty) | `` |
+| 08 | `None` | `` |
+| 09 | `+91 98765-43210` (via creation) | `9876543210` |
+
+---
+
+### 6. `test_portal_lead_processing.py` - Lead Processing
+
+**Class:** `TestPortalLeadProcessing(PortalLeadTestCase)`  
+**Model Under Test:** `leads.new`  
+**Total Tests:** 11
+
+| Test ID | Method | Description |
+|---------|--------|-----------|
+| 01-04 | `test_0X_find_property_by_*` | Property lookup by portal ID |
+| 05 | `test_05_property_not_found_returns_empty` | Empty recordset on not found |
+| 06 | `test_06_find_rm_from_property` | RM extraction from property |
+| 07 | `test_07_process_lead_assigns_property_and_rm` | Full processing flow |
+| 08 | `test_08_process_lead_property_not_found_assigns_naresh` | Fallback assignment |
+| 09 | `test_09_process_lead_adds_notes` | Processing notes |
+| 10 | `test_10_process_lead_skips_non_new_leads` | Skip already processed |
+| 11 | `test_11_process_ops_lead_assignment` | OPS sales lead processing |
+
+#### Property Matching Logic:
+
+```python
+Portal Name          → Property Field Searched
+─────────────────────────────────────────────
+'MagicBricks'        → magicbricks_id
+'Housing.com'        → housing_id
+'99acres'            → ninety_nine_acres_id
+'OLX'                → olx_id
+```
+
+#### OPS Sales Lead Flag:
+
+```python
+# is_ops_sales_lead field behavior:
+- Default: False (standard leads)
+- True: Marks lead as OPS sales lead
+- Processing: Flag preserved during lead assignment
+- RM Assignment: Still assigns RM even when is_ops_sales_lead=True
+```
+
+---
+
+### 7. `test_portal_lead_whatsapp.py` - WhatsApp Integration
+
+**Class:** `TestPortalLeadWhatsapp(PortalLeadTestCase)`  
+**Model Under Test:** `leads.new`  
+**Total Tests:** 5
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_whatsapp_url_10_digit_phone` | URL with 10-digit phone |
+| 02 | `test_02_whatsapp_url_with_91_prefix` | URL with existing prefix |
+| 03 | `test_03_whatsapp_url_no_phone` | Returns False when no phone |
+| 04 | `test_04_whatsapp_html_includes_icon` | HTML includes fa-whatsapp icon |
+| 05 | `test_05_action_whatsapp_generates_message` | Action returns proper context |
+
+#### WhatsApp URL Format:
+
+```
+Input: 9876543210
+Output: whatsapp://send?phone=919876543210
+```
+
+---
+
+### 8. `test_portal_lead_cron.py` - Scheduled Jobs
+
+**Class:** `TestPortalLeadCron(PortalLeadTestCase)`  
+**Model Under Test:** `leads.new`  
+**Total Tests:** 3
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_cron_reprocesses_old_unassigned_leads` | Process leads >1 hour old |
+| 02 | `test_02_cron_skips_recent_leads` | Skip leads <1 hour old |
+| 03 | `test_03_cron_skips_already_assigned` | Skip assigned leads |
+
+#### Cron Method: `_cron_reprocess_unassigned_leads`
+
+```
+Criteria for reprocessing:
+├── state = 'new'
+├── create_date < (now - 1 hour)
+└── Not already assigned
+```
+
+---
+
+### 9. `test_portal_lead_api.py` - External API Integration
+
+**Class:** `TestPortalLeadAPI(PortalLeadTestCase)`  
+**Model Under Test:** `leads.new`  
+**Total Tests:** 4
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_housing_api_fetch_success` | Successful API fetch |
+| 02 | `test_02_housing_api_no_leads` | Handle empty response |
+| 03 | `test_03_housing_api_error` | Handle connection errors |
+| 04 | `test_04_cron_full_flow` | Full integration test |
+
+#### Mocking Setup:
+
+```python
+# Mock requests.get for API tests
+@patch('requests.get')
+def test_01_housing_api_fetch_success(self, mock_get):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'data': [...]}
+    mock_get.return_value = mock_response
+```
+
+---
+
+### 10. `test_portal_lead_webhook.py` - Webhook Functionality
+
+**Class:** `TestPortalLeadWebhook(PortalLeadTestCase)`  
+**Model Under Test:** `leads.new`  
+**Total Tests:** 3
+
+| Test ID | Method | Description |
+|---------|--------|-------------|
+| 01 | `test_01_webhook_sends_unsent_leads` | Sends to n8n webhook |
+| 02 | `test_02_webhook_includes_property_details` | Payload contains property info |
+| 03 | `test_03_webhook_skips_if_url_not_configured` | Skip when URL not set |
+
+#### System Parameters Used:
+
+```python
+'n8n.new_lead_webhook_url'  # Webhook endpoint URL
+'housing.api.key'           # Housing.com API key
+'housing.api.id'            # Housing.com API ID
+```
+
+---
+
+## Test Coverage Matrix
+
+| Feature | CRUD | Compute | Validation | Integration | Cron |
+|---------|:----:|:-------:|:----------:|:-----------:|:----:|
+| Lead Creation | ✅ | | ✅ | | |
+| Phone Standardization | ✅ | ✅ | ✅ | | |
+| Duplicate Detection | | ✅ | ✅ | | |
+| Property Matching | | ✅ | | ✅ | |
+| RM Assignment | | ✅ | | ✅ | ✅ |
+| WhatsApp URLs | | ✅ | | | |
+| Follow-up Dates | | ✅ | | | ✅ |
+| External API | | | | ✅ | ✅ |
+| Webhooks | | | | ✅ | ✅ |
+| Lead Scoring | ✅ | ✅ | ✅ | | ✅ |
+
+---
+
+## Common Test Fixtures
+
+### Creating Test Data with Time Manipulation
+
+```python
+# Force a record to appear old (bypass ORM readonly)
+from datetime import timedelta
+from odoo import fields
+
+old_date = fields.Datetime.now() - timedelta(days=31)
+self.env.cr.execute(
+    "UPDATE leads_new SET create_date = %s WHERE id = %s", 
+    (old_date, lead.id)
+)
+lead.invalidate_recordset()
+```
+
+### Mocking External Services
+
+```python
+from unittest.mock import patch, MagicMock
+
+@patch('requests.post')
+def test_webhook(self, mock_post):
+    mock_post.return_value.raise_for_status = lambda: None
+    # ... test code
+```
+
+### Expecting Database Errors
+
+```python
+from odoo.tools import mute_logger
+import psycopg2
+
+with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.IntegrityError):
+    # Code that should raise IntegrityError
+```
+
+---
+
+## Best Practices
+
+### 1. Test Independence
+
+Each test should be independent and not rely on state from other tests:
+
+```python
+def setUp(self):
+    """Create fresh data for each test."""
+    super().setUp()
+    self.lead = self.create_portal_lead()
+```
+
+### 2. Use Dynamic IDs
+
+Avoid hardcoded IDs that may conflict:
+
+```python
+# ✅ Good
+cls.suffix = str(int(time.time()))
+cls.mb_id = f'MB_{cls.suffix}'
+
+# ❌ Bad
+cls.mb_id = 'MB_12345'
+```
+
+### 3. Cache Invalidation
+
+Always invalidate cache after direct SQL or when testing computed fields:
+
+```python
+lead.invalidate_recordset(['field_name'])
+# or
+lead.invalidate_recordset()  # All fields
+```
+
+### 4. Test Naming Convention
+
+```
+test_{order}_{description}
+
+Examples:
+- test_01_create_lead_with_required_fields
+- test_02_missing_required_fields
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. Tests Not Running
+
+```bash
+# Ensure module is installed
+python odoo-bin -c odoo.conf -d <db> -i leads --stop-after-init
+
+# Then run tests
+python odoo-bin -c odoo.conf -d <db> --test-enable --stop-after-init -u leads
+```
+
+#### 2. IntegrityError Not Raised
+
+Ensure you're using `mute_logger` and the correct exception:
+
+```python
+from odoo.tools import mute_logger
+import psycopg2
+
+with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.IntegrityError):
+    # ...
+```
+
+#### 3. Computed Field Not Updating
+
+```python
+# Force recomputation
+record.invalidate_recordset(['computed_field'])
+# OR
+record._compute_field_name()
+```
+
+#### 4. Cron Job Test Failures
+
+```python
+# Flush ORM before raw SQL
+self.env.flush_all()
+
+# Then execute SQL
+self.env.cr.execute("UPDATE ...")
+
+# Invalidate cache
+record.invalidate_recordset()
+```
+
+---
+
+## Contributing
+
+When adding new tests:
+
+1. Follow the existing naming conventions
+2. Inherit from `PortalLeadTestCase` for portal lead tests
+3. Use `@tagged('post_install', '-at_install')` decorator
+4. Add test to `__init__.py` imports
+5. Update this README with new test documentation
+
+---
+
+## License
+
+This test suite is part of the Leads module and follows the same licensing as the parent Odoo project.
+
+---
+
+*Last Updated: January 2026*  
+*Odoo Version: 19.0*

--- a/custom_addons/leads/tests/test_portal_lead_crud.py
+++ b/custom_addons/leads/tests/test_portal_lead_crud.py
@@ -68,3 +68,29 @@ class TestPortalLeadCRUD(PortalLeadTestCase):
         self.assertEqual(lead.site_visit_date_only.day, 25)
         self.assertEqual(lead.site_visit_date_only.month, 12)
         self.assertEqual(lead.site_visit_date_only.year, 2025)
+
+    def test_07_ops_sales_lead_flag(self):
+        """
+        Test that is_ops_sales_lead flag functions correctly.
+        1. Verifies default is False.
+        2. Verifies explicit assignment to True.
+        """
+        # Case 1: Default Behavior
+        # We rely on your existing helper. Since we don't pass the flag, 
+        # it should default to False (standard boolean behavior in Odoo).
+        lead_default = self.create_portal_lead(name="Standard Lead")
+        self.assertFalse(
+            lead_default.is_ops_sale_lead, 
+            "is_ops_sale_lead should default to False"
+        )
+
+        # Case 2: Explicit Creation
+        # We pass the new field via **kwargs to your helper
+        lead_ops = self.create_portal_lead(
+            name="OPS Specialized Lead",
+            is_ops_sale_lead=True
+        )
+        self.assertTrue(
+            lead_ops.is_ops_sale_lead, 
+            "is_ops_sale_lead should be True when explicitly set"
+        )

--- a/custom_addons/leads/tests/test_portal_lead_processing.py
+++ b/custom_addons/leads/tests/test_portal_lead_processing.py
@@ -111,3 +111,31 @@ class TestPortalLeadProcessing(PortalLeadTestCase):
         self.assertFalse(lead.property_id)
         self.assertEqual(lead.user_id, original_user)
         self.assertEqual(lead.state, 'assigned')
+
+    def test_11_process_ops_lead_assignment(self):
+        """
+        Test that an OPS sales lead is processed and assigned correctly.
+        Ensures the flag does not interfere with standard RM assignment.
+        """
+        # Create an OPS lead
+        lead = self.create_portal_lead(
+            name="OPS Processing Test",
+            portal_name='MagicBricks',
+            portal_property_id=self.mb_id, 
+            is_ops_sale_lead=True  # Ensure this matches your singular field name
+        )
+        
+        # Trigger processing
+        lead._process_lead_logic()  # Using the internal logic method consistent with other tests
+        
+        # Verification 1: Flag remains True
+        self.assertTrue(lead.is_ops_sale_lead, "Processing should not alter OPS flag")
+        
+        # Verification 2: RM was still assigned
+        # Since we passed a valid 'portal_property_id' (self.mb_id) that links to 'self.test_property',
+        # and 'self.test_property' has 'self.rm_user', the lead should be assigned to that RM.
+        self.assertEqual(
+            lead.user_id, 
+            self.rm_user, 
+            "OPS Leads should still be assigned an RM if property matches"
+        )

--- a/custom_addons/leads/views/new_portal_lead_views.xml
+++ b/custom_addons/leads/views/new_portal_lead_views.xml
@@ -67,6 +67,10 @@
                                  ('interest_ids.site_visit_date_only', '=', context_today())
                                 ]"
                         help="Primary or recommended property site visit scheduled for today (IST)"/>
+                
+                <filter string="Ops Sales Leads"
+                        name="ops_sales_leads"
+                        domain="[('is_ops_sale_lead', '=', True)]"/>
 
                 <separator/>
 
@@ -204,6 +208,7 @@
                                     <field name="property_location"/>
                                     <field name="property_link" widget="url"/>
                                     <field name="property_bhk"/>
+                                    <field name="is_ops_sale_lead" widget="boolean"/>
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
Added comprehensive README.md documentation for test suites in cleardeals_dashboards, lead_suggestor, and leads modules. Introduced a new boolean field 'is_ops_sale_lead' to the NewPortalLead model. Updated and expanded tests for portal leads, including CRUD, processing, and computed field coverage.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
