### PR TITLE
Expand feedback options for site visit and improve sorting

### DIFF
--- a/custom_addons/cleardeals_dashboards/models/lead_scoring_lead.py
+++ b/custom_addons/cleardeals_dashboards/models/lead_scoring_lead.py
@@ -119,7 +119,8 @@ class LeadScoringLead(models.Model):
             lead.has_replied = bool(inbound)
             
             if inbound:
-                lead.last_response = inbound.sorted(key=lambda r: r.event_timestamp, reverse=True)[0].message_content
+                # Sort by timestamp desc, then by id desc for deterministic ordering when timestamps match
+                lead.last_response = inbound.sorted(key=lambda r: (r.event_timestamp, r.id), reverse=True)[0].message_content
             else:
                 lead.last_response = False
 

--- a/custom_addons/leads/models/lead_property_interest.py
+++ b/custom_addons/leads/models/lead_property_interest.py
@@ -74,11 +74,17 @@ class LeadPropertyInterest(models.Model):
     ], string='Feedback')
 
     feedback_site_visit_done = fields.Selection([
-        ('requirements_not_matching', 'Requirements Not Matching'),
         ('buyer_liked_property', 'Buyer Liked Property'),
         ('buyer_requirement_closed', 'Buyer Requirement Closed'),
         ('buyer_visit_from_outside', 'Buyer Visit From Outside'),
         ('buyer_not_pickup_call', 'Buyer Not Picking Call'),
+        ('planning_for_second_visit', 'Planning for Second Visit'),
+        ('negotiation_stage', 'Negotiation Stage'),
+        ('visit_done_confirmed_by_owner', 'Visit Done - Confirmed by Owner'),
+        ('looking_for_more_options', 'Looking for More Options'),
+        ('price_is_high', 'Price is High'),
+        ('location_mismatch', 'Location Mismatch'),
+        ('deal_closed', 'Deal Closed'),
         ('other', 'Other')
     ], string='Feedback for Site Visit Done')
 

--- a/custom_addons/leads/models/new_portal_leads.py
+++ b/custom_addons/leads/models/new_portal_leads.py
@@ -68,11 +68,17 @@ class NewPortalLead(models.Model):
     ], string='Feedback')
 
     feedback_site_visit_done = fields.Selection([
-        ('requirements_not_matching', 'Requirements Not Matching'),
         ('buyer_liked_property', 'Buyer Liked Property'),
         ('buyer_requirement_closed', 'Buyer Requirement Closed'),
         ('buyer_visit_from_outside', 'Buyer Visit From Outside'),
         ('buyer_not_pickup_call', 'Buyer Not Picking Call'),
+        ('planning_for_second_visit', 'Planning for Second Visit'),
+        ('negotiation_stage', 'Negotiation Stage'),
+        ('visit_done_confirmed_by_owner', 'Visit Done - Confirmed by Owner'),
+        ('looking_for_more_options', 'Looking for More Options'),
+        ('price_is_high', 'Price is High'),
+        ('location_mismatch', 'Location Mismatch'),
+        ('deal_closed', 'Deal Closed'),
         ('other', 'Other')
     ], string='Feedback for Site Visit Done')
 

--- a/custom_addons/leads/tests/README.md
+++ b/custom_addons/leads/tests/README.md
@@ -440,12 +440,18 @@ def test_01_housing_api_fetch_success(self, mock_get):
 - 'other'                         # Other
 
 # feedback_site_visit_done options:
-- 'requirements_not_matching'     # Requirements Not Matching
-- 'buyer_liked_property'          # Buyer Liked Property
-- 'buyer_requirement_closed'      # Buyer Requirement Closed
-- 'buyer_visit_from_outside'      # Buyer Visit From Outside
-- 'buyer_not_pickup_call'         # Buyer Not Picking Call
-- 'other'                         # Other
+- 'buyer_liked_property'              # Buyer Liked Property
+- 'buyer_requirement_closed'          # Buyer Requirement Closed
+- 'buyer_visit_from_outside'          # Buyer Visit From Outside
+- 'buyer_not_pickup_call'             # Buyer Not Picking Call
+- 'planning_for_second_visit'         # Planning for Second Visit
+- 'negotiation_stage'                 # Negotiation Stage
+- 'visit_done_confirmed_by_owner'     # Visit Done - Confirmed by Owner
+- 'looking_for_more_options'          # Looking for More Options
+- 'price_is_high'                     # Price is High
+- 'location_mismatch'                 # Location Mismatch
+- 'deal_closed'                       # Deal Closed
+- 'other'                             # Other
 ```
 
 #### Unique Constraint (Odoo 19.0 Syntax):

--- a/custom_addons/leads/tests/test_lead_property_interest.py
+++ b/custom_addons/leads/tests/test_lead_property_interest.py
@@ -208,11 +208,17 @@ class TestLeadPropertyInterest(PortalLeadTestCase):
         
         # Test all valid options
         valid_options = [
-            'requirements_not_matching',
             'buyer_liked_property',
             'buyer_requirement_closed',
             'buyer_visit_from_outside',
             'buyer_not_pickup_call',
+            'planning_for_second_visit',
+            'negotiation_stage',
+            'visit_done_confirmed_by_owner',
+            'looking_for_more_options',
+            'price_is_high',
+            'location_mismatch',
+            'deal_closed',
             'other',
         ]
         

--- a/custom_addons/leads/tests/test_portal_lead_crud.py
+++ b/custom_addons/leads/tests/test_portal_lead_crud.py
@@ -142,11 +142,17 @@ class TestPortalLeadCRUD(PortalLeadTestCase):
 
         # Case 2: Test all valid selection values
         valid_feedback_options = [
-            'requirements_not_matching',
             'buyer_liked_property',
             'buyer_requirement_closed',
             'buyer_visit_from_outside',
             'buyer_not_pickup_call',
+            'planning_for_second_visit',
+            'negotiation_stage',
+            'visit_done_confirmed_by_owner',
+            'looking_for_more_options',
+            'price_is_high',
+            'location_mismatch',
+            'deal_closed',
             'other',
         ]
         


### PR DESCRIPTION
Added new feedback options for 'feedback_site_visit_done' in lead property interest and portal leads models, and updated related tests and documentation. Also improved sorting logic for last response in lead scoring to ensure deterministic ordering when timestamps match.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
