### PR TITLE
CLMAI-406 Normalize and robust phone matching

### DIFF
--- a/custom_addons/leads/controllers/shared/property_resolver.py
+++ b/custom_addons/leads/controllers/shared/property_resolver.py
@@ -14,18 +14,29 @@ across summary, funnel, activity, site_visits, etc.
 """
 
 import logging
+import re
+
+from .phone_utils import normalize_phone_to_10_digit
 
 _logger = logging.getLogger(__name__)
 
 
 def get_properties_for_phone(env, phone_10: str):
     """
-    Return all property.base records whose owner_phone
-    normalises to `phone_10` (a clean 10-digit string).
+    Return all property.base records whose owner_phone contains `phone_10`.
 
-    Odoo stores owner_phone in various formats (with/without 91, spaces, etc.),
-    so we search by the raw stored value first, then fall back to the 91-prefix
-    format.
+    owner_phone may be stored in several real-world formats:
+      - Single number, clean:       "9028233802"
+      - Single number, with prefix: "919028233802" | "+919028233802"
+      - Multiple numbers, space-separated: "9316108956 8780576009"
+
+    Strategy:
+      1. SQL LIKE to cheaply narrow candidates to rows that contain the
+         10-digit string as a substring.
+      2. Python token filter: split on whitespace/commas, normalise each
+         token, accept the record only if any token normalises to phone_10.
+         This avoids false positives where the 10-digit string appears
+         embedded inside a longer number.
 
     Parameters
     ----------
@@ -38,24 +49,26 @@ def get_properties_for_phone(env, phone_10: str):
     """
     PropertyInventory = env["property.base"].sudo()
 
-    # Primary match: stored as exact 10-digit
-    props = PropertyInventory.search(
-        [
-            ("owner_phone", "=", phone_10),
-        ],
+    # Step 1: broad SQL match — finds rows where phone_10 appears anywhere
+    # in the stored string (handles all prefix/multi-number variants).
+    candidates = PropertyInventory.search(
+        [("owner_phone", "like", phone_10)],
     )
 
-    if not props:
-        # Fallback: stored with country code "91XXXXXXXXXX"
-        props = PropertyInventory.search(
-            [
-                ("owner_phone", "=", f"91{phone_10}"),
-            ],
-        )
+    # Step 2: exact token match in Python — each space/comma-separated token
+    # is normalised; accept the record if any token resolves to phone_10.
+    def _any_token_matches(stored: str) -> bool:
+        for token in re.split(r"[\s,;]+", stored or ""):
+            if normalize_phone_to_10_digit(token.strip()) == phone_10:
+                return True
+        return False
+
+    props = candidates.filtered(lambda p: _any_token_matches(p.owner_phone))
 
     _logger.debug(
-        "property_resolver: phone=%s -> %d properties found",
+        "property_resolver: phone=%s -> %d candidates, %d matched",
         phone_10,
+        len(candidates),
         len(props),
     )
     return props

--- a/custom_addons/leads/tests/test_portal_lead_duplicate.py
+++ b/custom_addons/leads/tests/test_portal_lead_duplicate.py
@@ -1,10 +1,12 @@
-# -*- coding: utf-8 -*-
-from odoo.tests import tagged
 from datetime import timedelta
+
 from odoo import fields
+from odoo.tests import tagged
+
 from .test_portal_common import PortalLeadTestCase
 
-@tagged('post_install', '-at_install')
+
+@tagged("post_install", "-at_install")
 class TestPortalLeadDuplicateDetection(PortalLeadTestCase):
     """
     Test duplicate lead detection logic.
@@ -14,109 +16,113 @@ class TestPortalLeadDuplicateDetection(PortalLeadTestCase):
         """Different phone numbers should not be duplicates."""
         # 1. Create Base Lead
         self.create_portal_lead(
-            phone='9876543210',
-            portal_property_id=self.mb_id # Use dynamic ID from Common
+            phone="9876543210",
+            portal_property_id=self.mb_id,  # Use dynamic ID from Common
         )
 
         # 2. Create Lead with Different Phone
         lead2_vals = {
-            'name': 'Lead 2',
-            'phone': '9876543211', # Different Phone
-            'portal_property_id': self.mb_id,
-            'portal_name': 'MagicBricks',
+            "name": "Lead 2",
+            "phone": "9876543211",  # Different Phone
+            "portal_property_id": self.mb_id,
+            "portal_name": "MagicBricks",
         }
 
-        lead2 = self.env['leads.new'].create_lead_if_not_duplicate(lead2_vals)
+        lead2 = self.env["leads.new"].create_lead_if_not_duplicate(lead2_vals)
         self.assertTrue(lead2, "Should create lead with different phone numbers")
 
     def test_02_no_duplicate_different_property(self):
         """Different property IDs should not be duplicates."""
         # 1. Create Base Lead
         self.create_portal_lead(
-            phone='9876543210',
-            portal_property_id=self.mb_id
+            phone="9876543210",
+            portal_property_id=self.mb_id,
         )
 
         # 2. Create Lead with Different Property ID
         lead2_vals = {
-            'name': 'Lead 3',
-            'phone': '9876543210', # Same Phone
-            'portal_property_id': self.mb_id + '_DIFF', # Different ID
-            'portal_name': 'MagicBricks',
+            "name": "Lead 3",
+            "phone": "9876543210",  # Same Phone
+            "portal_property_id": self.mb_id + "_DIFF",  # Different ID
+            "portal_name": "MagicBricks",
         }
 
-        lead2 = self.env['leads.new'].create_lead_if_not_duplicate(lead2_vals)
+        lead2 = self.env["leads.new"].create_lead_if_not_duplicate(lead2_vals)
         self.assertTrue(lead2, "Should create lead with different property IDs")
 
     def test_03_duplicate_same_phone_and_property_recent(self):
         """Same phone + property within 30 days should be duplicate (return False)."""
         # 1. Create Base Lead
         self.create_portal_lead(
-            phone='9876543210',
-            portal_property_id=self.mb_id
+            phone="9876543210",
+            portal_property_id=self.mb_id,
         )
 
         # 2. Create Exact Duplicate (Same Phone, Same Property, Recent)
         lead2_vals = {
-            'name': 'Lead 4',
-            'phone': '9876543210',
-            'portal_property_id': self.mb_id,
-            'portal_name': 'MagicBricks',
+            "name": "Lead 4",
+            "phone": "9876543210",
+            "portal_property_id": self.mb_id,
+            "portal_name": "MagicBricks",
         }
 
-        lead2 = self.env['leads.new'].create_lead_if_not_duplicate(lead2_vals)
+        lead2 = self.env["leads.new"].create_lead_if_not_duplicate(lead2_vals)
         self.assertFalse(lead2, "Should NOT create duplicate lead (Recent)")
 
     def test_04_not_duplicate_after_30_days(self):
         """Same lead after 30 days should be allowed."""
         # 1. Create Old Lead
         old_lead = self.create_portal_lead(
-            phone='9876543210',
-            portal_property_id=self.mb_id
+            phone="9876543210",
+            portal_property_id=self.mb_id,
         )
 
         # 2. Force date to 31 days ago via SQL to bypass ORM readonly check
         old_date = fields.Datetime.now() - timedelta(days=31)
         self.env.cr.execute(
-            "UPDATE leads_new SET create_date = %s WHERE id = %s", 
-            (old_date, old_lead.id)
+            "UPDATE leads_new SET create_date = %s WHERE id = %s",
+            (old_date, old_lead.id),
         )
         old_lead.invalidate_recordset()
 
         # 3. Create Duplicate (Should Pass now)
         new_lead_vals = {
-            'name': 'New Lead',
-            'phone': '9876543210',
-            'portal_property_id': self.mb_id,
-            'portal_name': 'MagicBricks',
+            "name": "New Lead",
+            "phone": "9876543210",
+            "portal_property_id": self.mb_id,
+            "portal_name": "MagicBricks",
         }
 
-        new_lead = self.env['leads.new'].create_lead_if_not_duplicate(new_lead_vals)
+        new_lead = self.env["leads.new"].create_lead_if_not_duplicate(new_lead_vals)
         self.assertTrue(new_lead, "Should create lead after 30 days expiration")
 
     def test_05_duplicate_detection_returns_none(self):
         """Duplicate detection should return None and not create a new lead."""
         # 1. Create Base Lead
         lead1 = self.create_portal_lead(
-            phone='9876543210',
-            portal_property_id=self.mb_id
+            phone="9876543210",
+            portal_property_id=self.mb_id,
         )
 
         # 2. Attempt Duplicate
         lead2_vals = {
-            'name': 'Duplicate',
-            'phone': '9876543210',
-            'portal_property_id': self.mb_id,
-            'portal_name': 'MagicBricks',
-            'raw_data': 'test data'
+            "name": "Duplicate",
+            "phone": "9876543210",
+            "portal_property_id": self.mb_id,
+            "portal_name": "MagicBricks",
+            "raw_data": "test data",
         }
 
-        result = self.env['leads.new'].create_lead_if_not_duplicate(lead2_vals)
+        result = self.env["leads.new"].create_lead_if_not_duplicate(lead2_vals)
 
         # 3. Verify duplicate was silently skipped (no new lead, no chatter noise)
         self.assertIsNone(result, "Duplicate should return None, not create a new lead")
-        duplicate_count = self.env['leads.new'].search_count([
-            ('phone', '=', '9876543210'),
-            ('portal_property_id', '=', self.mb_id),
-        ])
-        self.assertEqual(duplicate_count, 1, "Only one lead should exist for this phone/property")
+        duplicate_count = self.env["leads.new"].search_count(
+            [
+                ("phone", "=", "9876543210"),
+                ("portal_property_id", "=", self.mb_id),
+            ]
+        )
+        self.assertEqual(
+            duplicate_count, 1, "Only one lead should exist for this phone/property"
+        )

--- a/custom_addons/properties/models/property_sync.py
+++ b/custom_addons/properties/models/property_sync.py
@@ -13,6 +13,23 @@ except ImportError:  # noqa: BLE001
 
 _logger = logging.getLogger(__name__)
 
+
+def _normalize_owner_phone(raw: str) -> str:
+    """
+    Strip formatting and country code from an Indian mobile number.
+    Returns a clean 10-digit string, or the raw value if it cannot be resolved.
+    """
+    if not raw:
+        return ""
+    digits = re.sub(r"\D", "", raw.strip())
+    if len(digits) == 10:
+        return digits
+    if len(digits) == 11 and digits.startswith("0"):
+        return digits[1:]
+    if len(digits) == 12 and digits.startswith("91"):
+        return digits[2:]
+    return raw  # unrecognised format — store as-is so data isn't lost
+
 # API endpoint for the Cleardeals property listing
 PROPERTY_API_URL = "https://api.cleardeals.cc/api/v1/properties"
 
@@ -188,7 +205,7 @@ def _map_api_record(api_item: dict) -> dict:
         "_exec_name": api_item.get("exec_name") or "",
         # Owner
         "owner_name": api_item.get("owner_name") or "",
-        "owner_phone": api_item.get("owner_contact_no") or "",
+        "owner_phone": _normalize_owner_phone(api_item.get("owner_contact_no") or ""),
         "owner_email": api_item.get("owner_email") or "",
         # Financials
         "pricing": _parse_pricing(api_item),


### PR DESCRIPTION
Improve handling of owner phone numbers across the codebase.

- leads/controllers/shared/property_resolver.py: use SQL LIKE to prefilter candidate property rows, then split stored owner_phone tokens and normalize each token (via normalize_phone_to_10_digit) to avoid false positives when the 10-digit string appears inside a longer value or in multi-number fields; update debug logging to report candidate vs matched counts.
- properties/models/property_sync.py: add _normalize_owner_phone to strip formatting and Indian country/prefixes from Cleardeals owner_contact_no and store a clean 10-digit value when possible.
- leads/tests/test_portal_lead_duplicate.py: minor test formatting/quoting and import/spacing cleanups (no behavioral change to test logic).

These changes make phone matching more robust for real-world stored formats (country codes, prefixes, multiple numbers, spacing) and reduce incorrect matches.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
