### PR TITLE
Replace legacy property fields with base fields

### DIFF
--- a/custom_addons/leads/models/new_portal_leads.py
+++ b/custom_addons/leads/models/new_portal_leads.py
@@ -164,49 +164,18 @@ class NewPortalLead(models.Model):
     )
 
     # ------------------------------------------------------------------
-    # Legacy related fields — sourced from property.inventory (property_id).
-    # These hold the stored values for all 6 000+ historical leads and
-    # remain the display source until property_base_id is fully backfilled.
-    # ------------------------------------------------------------------
-    property_bhk = fields.Char(
-        related="property_id.bhk",
-        string="Property BHK (Legacy)",
-        readonly=True,
-        store=True,
-    )
-
-    property_location = fields.Char(
-        related="property_id.location",
-        string="Property Location (Legacy)",
-        readonly=True,
-        store=True,
-    )
-
-    property_city = fields.Char(
-        related="property_id.city",
-        string="Property City (Legacy)",
-        readonly=True,
-        store=True,
-    )
-
-    property_owner_name = fields.Char(
-        related="property_id.owner_name",
-        string="Property Owner (Legacy)",
-        readonly=True,
-        store=True,
-    )
-
-    property_link = fields.Char(
-        related="property_id.property_link",
-        string="Property Link (Legacy)",
-        readonly=True,
-    )
-
-    # ------------------------------------------------------------------
     # New related fields — sourced from property.base (property_base_id).
     # Populated as property_base_id gets backfilled / set on new leads.
     # Once the migration is complete these become the primary display fields.
     # ------------------------------------------------------------------
+
+    base_property_tag = fields.Char(
+        related="property_base_id.property_tag",
+        string="Property Tag",
+        readonly=True,
+        store=True,
+    )
+
     base_property_bhk = fields.Char(
         related="property_base_id.bhk",
         string="Property BHK",
@@ -364,7 +333,10 @@ class NewPortalLead(models.Model):
         # Context must be set on `self` before super() — calling
         # super().with_context().create() returns the same overridden method
         # and causes infinite recursion.
-        new_leads = super(NewPortalLead, self.with_context(mail_create_nolog=True)).create(vals_list)
+        new_leads = super(
+            NewPortalLead,
+            self.with_context(mail_create_nolog=True),
+        ).create(vals_list)
         channel = "leads.new"
         notification_type = "bus_notification"
         message = {

--- a/custom_addons/leads/views/new_portal_lead_views.xml
+++ b/custom_addons/leads/views/new_portal_lead_views.xml
@@ -10,11 +10,8 @@
                 <field name="phone"/>
                 <field name="user_id" string="RM"/>
                 <field name="base_property_location" string="Location"/>
-                <field name="property_location" string="Location (Legacy)" groups="leads.group_lead_score_manager"/>
-
+                <field name="base_property_tag" string="Property Tag"/>
                 <field name="all_associated_properties" string="Property (Primary or Recommended)"/>
-                <field name="property_base_id" string="Primary Property"/>
-                <field name="property_id" string="Primary Property (Legacy)" groups="leads.group_lead_score_manager"/>
                 <field name="base_property_bhk" string="BHK"/>
                 <field name="base_property_city" string="City"/>
                 <field name="portal_name"/>
@@ -113,13 +110,11 @@
                     invisible="phone_whatsapp_url == False"/>
                 <field name="portal_property_id"/>
                 <field name="property_base_id" string="Property"/>
-                <field name="property_id" string="Property (Legacy)" groups="leads.group_lead_score_manager" optional="hide"/>
                 <field name="user_id"/>
                 <field name="current_status"/>
                 <field name="interest_ids" widget="one2many"  optional="hide">
                     <list>
                         <field name="property_base_id" string="Property"/>
-                        <field name="property_id" string="Property (Legacy)" groups="leads.group_lead_score_manager" optional="hide"/>
                         <field name="current_status"/>
                     </list>
                 </field>
@@ -141,7 +136,6 @@
                         <group>
                             <field name="lead_id" readonly="1" force_save="1"/>
                             <field name="property_base_id" string="Property" force_save="1"/>
-                            <field name="property_id" string="Property (Legacy)" force_save="1" groups="leads.group_lead_score_manager"/>
                         </group>
                         <group>
                             <field name="property_bhk" readonly="1"/>
@@ -207,7 +201,7 @@
                                 <group>
                                     <field name="user_id"/>
                                     <field name="property_base_id" string="Property"/>
-                                    <field name="property_id" string="Property (Legacy)" groups="leads.group_lead_score_manager"/>
+                                    <field name="base_property_tag" string="Property Tag"/>
                                     <field name="current_status"/>
                                     <field name="site_visit_date"
                                            invisible="current_status != 'site_visit_scheduled'"/>
@@ -223,12 +217,6 @@
                                     <field name="base_property_owner_name" string="Owner"/>
                                     <field name="is_ops_sale_lead" widget="boolean"/>
                                 </group>
-                                <!-- Legacy fields — visible to managers only until backfill is complete -->
-                                <group string="Legacy Property Info" groups="leads.group_lead_score_manager">
-                                    <field name="property_location" string="Location (Legacy)"/>
-                                    <field name="property_link" string="Link (Legacy)" widget="url"/>
-                                    <field name="property_bhk" string="BHK (Legacy)"/>
-                                </group>
                             </group>
                         </page>
 
@@ -236,8 +224,6 @@
                             <field name="interest_ids" nolabel="1">
                                 <list>
                                     <field name="property_base_id" string="Property"/>
-                                    <field name="property_id" string="Property (Legacy)" groups="leads.group_lead_score_manager" optional="hide"/>
-                                    <field name="property_bhk"/>
                                     <field name="property_location"/>
                                     <field name="current_status"/>
                                     <field name="remarks"/>

--- a/custom_addons/properties/views/property_base_views.xml
+++ b/custom_addons/properties/views/property_base_views.xml
@@ -144,15 +144,15 @@
 
                         <!-- Service dates — manager-editable -->
                         <group string="Service">
-                            <field name="service_expiry_date"
-                                   groups="properties.group_property_manager"/>
-                            <field name="service_expiry_date_display"
-                                   string="Expiry (display)"
-                                   readonly="1"/>
                             <field name="welcome_call_date"
                                    groups="properties.group_property_manager"/>
                             <field name="welcome_call_date_display"
                                    string="Welcome Call (display)"
+                                   readonly="1"/>
+                            <field name="service_expiry_date"
+                                   groups="properties.group_property_manager"/>
+                            <field name="service_expiry_date_display"
+                                   string="Expiry (display)"
                                    readonly="1"/>
                             <field name="inventory_migrated" readonly="1"
                                    groups="properties.group_property_manager"/>


### PR DESCRIPTION
Remove legacy related fields sourced from property.inventory (property_id) from leads model and views and replace them with fields sourced from property.base (property_base_id). Add base_property_tag, expose base_property_* fields in lead forms/lists, and remove legacy-only fields/groups previously visible to managers. Also tidy the NewPortalLead.create() call formatting and reorder service expiry/welcome call fields in property_base view. These changes support the migration to property_base as the primary source for property info.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
