### PR TITLE
Enhance UI, security rules, and documentation for property management

### DIFF
--- a/.github/skills/odoo-pre-push-review/SKILL.md
+++ b/.github/skills/odoo-pre-push-review/SKILL.md
@@ -58,7 +58,13 @@ Read: `references/manifest.md` for detailed rules.
 Quick checklist:
 - `version` must be ≥ highest migration folder version number
 - Every new model's view file must appear in `data` list
-- Every Python model file must be imported in `models/__init__.py`
+- Every Python model file must be imported in `models/__init__.py` — **verify
+  this actively**: use `file_search` to list every `models/*.py` file in the
+  module, then read `models/__init__.py` and confirm every file (except
+  `__init__.py` itself) appears as a `from . import <name>` line. A file that
+  exists on disk but is missing from `__init__.py` is silently ignored by Odoo
+  — no error, no warning, the model simply does not load. This is the most
+  common silent omission bug and the easiest to miss in review.
 - The `controllers` key does nothing — flag it for removal and verify
   controllers are imported in `controllers/__init__.py` instead
 - `data` list load order: security XML first, then access CSV, then data XML,

--- a/custom_addons/leads/models/lead_site_visit.py
+++ b/custom_addons/leads/models/lead_site_visit.py
@@ -1,3 +1,5 @@
+import re
+
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -164,6 +166,15 @@ class LeadSiteVisitFeedbackOption(models.Model):
     requires_note = fields.Boolean(default=False)
     sequence = fields.Integer(default=10)
     active = fields.Boolean(default=True, index=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get("code") and vals.get("name"):
+                vals["code"] = re.sub(
+                    r"[^a-z0-9]+", "_", vals["name"].strip().lower()
+                ).strip("_")
+        return super().create(vals_list)
 
     def write(self, vals):
         if "code" in vals:

--- a/custom_addons/leads/models/property_base_extend.py
+++ b/custom_addons/leads/models/property_base_extend.py
@@ -30,6 +30,27 @@ class PropertyBaseLeadRelink(models.Model):
     _name = "property.base"
     _inherit = "property.base"
 
+    def _check_access(self, operation):
+        """Allow Leads RMs to read any property record.
+
+        The properties module restricts RMs to their own properties via
+        ir.rule domain ``[('rm_user_id', '=', user.id)]``.  This is correct
+        for the Properties list view (controlled by ``_search`` which applies
+        the ir.rule domain in SQL — unaffected by this override).
+
+        However, when an RM opens a recommended inquiry the form must read
+        the linked property.base record which may belong to a different RM.
+        ``_check_access`` is the gate for individual record reads; bypassing
+        it here lets the read succeed without broadening ``_search`` results.
+        """
+        if (
+            operation == 'read'
+            and not self.env.su
+            and self.env.user.has_group('leads.group_lead_score_rm')
+        ):
+            return None
+        return super()._check_access(operation)
+
     def write(self, vals):
         # Collect which portal fields are being updated and their new values
         changed_portals = {

--- a/custom_addons/leads/security/security.xml
+++ b/custom_addons/leads/security/security.xml
@@ -91,6 +91,6 @@
             <field name="perm_unlink" eval="True"/>
             <field name="domain_force">[(1, '=', 1)]</field>
         </record>
-        
+
     </data>
 </odoo>

--- a/custom_addons/leads/static/src/css/property_activity_widget.css
+++ b/custom_addons/leads/static/src/css/property_activity_widget.css
@@ -310,7 +310,15 @@
 /* Cell helpers */
 .cd-cell-date  { white-space: nowrap; color: #6c757d; }
 .cd-cell-phone { white-space: nowrap; font-family: monospace; font-size: 11px; }
-.cd-cell-remarks { font-style: italic; color: #6c757d; font-size: 11px; }
+.cd-cell-remarks {
+    font-style: italic;
+    color: #6c757d;
+    font-size: 11px;
+    max-width: 180px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 
 .cd-pa-count {
     margin-top: 8px;

--- a/custom_addons/leads/static/src/xml/property_activity_widget.xml
+++ b/custom_addons/leads/static/src/xml/property_activity_widget.xml
@@ -280,7 +280,7 @@
                                             </t>
                                             <t t-else="">—</t>
                                         </td>
-                                        <td class="cd-cell-remarks">
+                                        <td class="cd-cell-remarks" t-att-title="grp.latest.feedback_note || ''">
                                             <t t-esc="grp.latest.feedback_note || '—'"/>
                                         </td>
                                     </tr>
@@ -304,7 +304,7 @@
                                                 </t>
                                                 <t t-else="">—</t>
                                             </td>
-                                            <td class="cd-cell-remarks">
+                                            <td class="cd-cell-remarks" t-att-title="hist.feedback_note || ''">
                                                 <t t-esc="hist.feedback_note || '—'"/>
                                             </td>
                                         </tr>

--- a/custom_addons/properties/security/property_security.xml
+++ b/custom_addons/properties/security/property_security.xml
@@ -58,7 +58,7 @@
             <field name="name">Property Base: RM sees own properties only</field>
             <field name="model_id" ref="model_property_base"/>
             <field name="groups" eval="[(4, ref('group_property_rm'))]"/>
-            <field name="domain_force">['|', ('rm_user_id', '=', user.id), (context.get('search_all_properties_for_lead'), '=', True)]</field>
+            <field name="domain_force">[('rm_user_id', '=', user.id)]</field>
             <field name="perm_read"   eval="True"/>
             <field name="perm_write"  eval="False"/>
             <field name="perm_create" eval="False"/>

--- a/custom_addons/properties/security/property_security.xml
+++ b/custom_addons/properties/security/property_security.xml
@@ -58,7 +58,7 @@
             <field name="name">Property Base: RM sees own properties only</field>
             <field name="model_id" ref="model_property_base"/>
             <field name="groups" eval="[(4, ref('group_property_rm'))]"/>
-            <field name="domain_force">[('rm_user_id', '=', user.id)]</field>
+            <field name="domain_force">['|', ('rm_user_id', '=', user.id), (context.get('search_all_properties_for_lead'), '=', True)]</field>
             <field name="perm_read"   eval="True"/>
             <field name="perm_write"  eval="False"/>
             <field name="perm_create" eval="False"/>


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the leads module, focusing on usability, access control, and data consistency. The main changes include enhanced UI for feedback notes, improved access for Relationship Managers (RMs) to property records, and automatic code generation for feedback options.

**UI and Usability Improvements:**

* Feedback note cells in the property activity widget are now truncated with ellipsis and display the full note on hover via the `title` attribute, improving readability and preventing layout issues for long remarks. (`custom_addons/leads/static/src/css/property_activity_widget.css`, `custom_addons/leads/static/src/xml/property_activity_widget.xml`) [[1]](diffhunk://#diff-b9d9bda876ec0a6bca9fb4ddc39a8d567696bb3416e717640a8ce9c561d20183L313-R321) [[2]](diffhunk://#diff-c7f8b833b92f608f608bf2281d6c622265615613b0a540df172d2ba7b4a8fe10L283-R283) [[3]](diffhunk://#diff-c7f8b833b92f608f608bf2281d6c622265615613b0a540df172d2ba7b4a8fe10L307-R307)

**Access Control Enhancements:**

* RMs can now read any property record when opening a recommended inquiry, even if the record belongs to another RM. This is achieved by overriding the `_check_access` method in `property.base`, bypassing the default access restriction for read operations in this context. (`custom_addons/leads/models/property_base_extend.py`)

**Data Consistency and Developer Guidance:**

* When creating new `LeadSiteVisitFeedbackOption` records, if a `code` is not provided but a `name` is, a code is automatically generated from the name (lowercased and sanitized). This reduces the risk of missing or inconsistent codes. (`custom_addons/leads/models/lead_site_visit.py`)
* The Odoo pre-push review checklist now includes a detailed instruction to actively verify that all Python model files are imported in `models/__init__.py`, helping prevent silent omission bugs. (`.github/skills/odoo-pre-push-review/SKILL.md`)

**Minor Code Quality:**

* Added a missing import for the `re` module in `lead_site_visit.py` to support the new code generation logic. (`custom_addons/leads/models/lead_site_visit.py`)Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
