### PR TITLE
Allow Leads RMs to read all property records

### DIFF
--- a/custom_addons/leads/models/property_base_extend.py
+++ b/custom_addons/leads/models/property_base_extend.py
@@ -1,6 +1,7 @@
 import logging
 
-from odoo import models
+from odoo import api, models
+from odoo.osv.expression import AND
 
 _logger = logging.getLogger(__name__)
 
@@ -25,31 +26,51 @@ class PropertyBaseLeadRelink(models.Model):
       1. Finds all unlinked leads.new with that portal_name + portal_property_id.
       2. Links property_base_id to this property.
       3. Reassigns user_id to the property's RM (if set).
+
+    Cross-RM read access
+    --------------------
+    Leads RMs need to read any property record to display it on a lead form
+    (e.g. a recommended property owned by a different RM).  This is handled
+    by an ir.rule (rule_property_base_leads_rm_read_all in
+    leads/security/security.xml) that ORs [(1,'=',1)] for the
+    ``leads.group_lead_score_rm`` group.  Odoo ORs rules across groups, so
+    the combined SQL domain becomes TRUE for leads RMs, letting _search()
+    return any property record.
+
+    To keep the Properties module list view showing only an RM's own
+    properties, the module's actions set the context key
+    ``properties_module_view=True``.  The _search override below detects
+    that key and injects [('rm_user_id','=',user.id)] back into the domain,
+    restoring the "own properties only" list while leaving cross-RM reads
+    unrestricted everywhere else.
     """
 
     _name = "property.base"
     _inherit = "property.base"
 
-    def _check_access(self, operation):
-        """Allow Leads RMs to read any property record.
+    @api.model
+    def _search(self, domain, offset=0, limit=None, order=None,
+                *, active_test=True, bypass_access=False):
+        """Restrict Properties module list view to own properties for RMs.
 
-        The properties module restricts RMs to their own properties via
-        ir.rule domain ``[('rm_user_id', '=', user.id)]``.  This is correct
-        for the Properties list view (controlled by ``_search`` which applies
-        the ir.rule domain in SQL — unaffected by this override).
-
-        However, when an RM opens a recommended inquiry the form must read
-        the linked property.base record which may belong to a different RM.
-        ``_check_access`` is the gate for individual record reads; bypassing
-        it here lets the read succeed without broadening ``_search`` results.
+        When the ``properties_module_view`` context key is set (injected by
+        every Properties module action), non-manager RM users only see their
+        own properties.  Outside that context (e.g. when Odoo fetches a
+        property record to display it on a lead form) the restriction is not
+        applied, so leads RMs can read any property record freely.
         """
         if (
-            operation == 'read'
-            and not self.env.su
-            and self.env.user.has_group('leads.group_lead_score_rm')
+            not self.env.su
+            and not bypass_access
+            and self.env.context.get('properties_module_view')
+            and self.env.user.has_group('properties.group_property_rm')
+            and not self.env.user.has_group('properties.group_property_manager')
         ):
-            return None
-        return super()._check_access(operation)
+            domain = AND([list(domain), [('rm_user_id', '=', self.env.user.id)]])
+        return super()._search(
+            domain, offset=offset, limit=limit, order=order,
+            active_test=active_test, bypass_access=bypass_access,
+        )
 
     def write(self, vals):
         # Collect which portal fields are being updated and their new values

--- a/custom_addons/leads/security/security.xml
+++ b/custom_addons/leads/security/security.xml
@@ -92,5 +92,31 @@
             <field name="domain_force">[(1, '=', 1)]</field>
         </record>
 
+        <!-- property.base cross-RM read access for Leads RMs
+             ─────────────────────────────────────────────────
+             The properties module restricts property.base reads to own records
+             via [('rm_user_id','=',user.id)] for group_property_rm.
+             Odoo ORs rules across groups, so adding [(1,'=',1)] here means
+             any user in leads.group_lead_score_rm can read ANY property record.
+             This is required so that:
+               - A lead form can display a recommended/linked property that
+                 belongs to a different RM (the Many2one display_name read
+                 goes through _search/_fetch which applies rules as SQL).
+             Write/create/unlink remain governed by the properties module.
+             The Properties module list view is kept tidy by the _search
+             override in leads/models/property_base_extend.py which re-applies
+             [('rm_user_id','=',user.id)] when context key
+             'properties_module_view' is present. -->
+        <record id="rule_property_base_leads_rm_read_all" model="ir.rule">
+            <field name="name">Property Base: Leads RM can read all properties</field>
+            <field name="model_id" ref="properties.model_property_base"/>
+            <field name="groups" eval="[(4, ref('leads.group_lead_score_rm'))]"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="perm_read"   eval="True"/>
+            <field name="perm_write"  eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+
     </data>
 </odoo>

--- a/custom_addons/leads/views/new_portal_lead_views.xml
+++ b/custom_addons/leads/views/new_portal_lead_views.xml
@@ -172,7 +172,8 @@
                     <group>
                         <group>
                             <field name="lead_id" readonly="1" force_save="1"/>
-                            <field name="property_base_id" string="Property" force_save="1"/>
+                            <field name="property_base_id" string="Property" force_save="1"
+                                   context="{'properties_module_view': True}"/>
                         </group>
                         <group>
                             <field name="base_property_bhk" readonly="1"/>
@@ -266,7 +267,8 @@
                             <group>
                                 <group>
                                     <field name="user_id"/>
-                                    <field name="property_base_id" string="Property"/>
+                                    <field name="property_base_id" string="Property"
+                                           context="{'properties_module_view': True}"/>
                                     <field name="base_property_tag" string="Property Tag"/>
                                     <field name="current_status"/>
                                     <field name="latest_site_visit_id" readonly="1"/>
@@ -293,7 +295,8 @@
                             <field name="child_inquiry_ids" nolabel="1">
                                 <list>
                                     <field name="name" string="Lead Name"/>
-                                    <field name="property_base_id" string="Property"/>
+                                    <field name="property_base_id" string="Property"
+                                           context="{'properties_module_view': True}"/>
                                     <field name="user_id" string="RM"/>
                                     <field name="current_status"/>
                                     <field name="state"/>

--- a/custom_addons/properties/views/property_base_views.xml
+++ b/custom_addons/properties/views/property_base_views.xml
@@ -326,7 +326,7 @@
         <field name="res_model">property.base</field>
         <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="view_property_base_search"/>
-        <field name="context">{'search_default_active_only': 1}</field>
+        <field name="context">{'search_default_active_only': 1, 'properties_module_view': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No properties found.
@@ -358,7 +358,7 @@
         <field name="view_mode">list,form</field>
         <field name="domain">[('prop_type', '=', 'residential')]</field>
         <field name="search_view_id" ref="view_property_base_search"/>
-        <field name="context">{'search_default_active_only': 1}</field>
+        <field name="context">{'search_default_active_only': 1, 'properties_module_view': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No residential properties found.
@@ -385,7 +385,7 @@
         <field name="view_mode">list,form</field>
         <field name="domain">[('prop_type', '=', 'commercial')]</field>
         <field name="search_view_id" ref="view_property_base_search"/>
-        <field name="context">{'search_default_active_only': 1}</field>
+        <field name="context">{'search_default_active_only': 1, 'properties_module_view': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No commercial properties found.


### PR DESCRIPTION
Add cross-RM read access so Leads RMs can fetch property.base records owned by other RMs while preserving the Properties module's list restrictions.

- Adds an ir.rule (leads: rule_property_base_leads_rm_read_all) granting leads.group_lead_score_rm read-only SQL access to property.base (domain [(1,'=',1)]). Write/create/unlink remain governed by Properties module rules.
- Replaces a previous _check_access override with a _search override on property.base that re-applies [('rm_user_id','=', user.id)] when the context key 'properties_module_view' is present and the user is a non-manager RM, keeping the Properties list view limited to the user's own properties while allowing cross-RM reads elsewhere.
- Updates views: injects context {'properties_module_view': True} where property_base_id is used in lead forms/lists and in Properties module actions so the list view behavior is preserved.
- Minor imports and expression handling updated (api, AND).

This change ensures lead forms can display recommended/linked properties across RMs without opening broad list access in the Properties UI.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
