### PR TITLE
Enhance lead duplicate detection to 180 days and update related behavior

### DIFF
--- a/custom_addons/leads/docs/orm-overrides.md
+++ b/custom_addons/leads/docs/orm-overrides.md
@@ -149,10 +149,13 @@ which the web client displays as a pop-up notification. The lead was successfull
 reassigned (the write did go through) but the UI shows an error, confusing the RM.
 
 **Why `sudo()` here is safe and not a security hole:** `sudo()` applies only to the
-confirmation read that returns data already visible to the RM (they just edited the record).
-The strict read rule continues to apply on every subsequent request — the reassigning RM
-loses access to the lead the moment they navigate away, because the rule checks `user_id`
-at read time and `user_id` no longer matches.
+confirmation read of the exact record that was just written (identified by `self` before
+the write). `next_id` is explicitly **not** honoured in the reassigning branch — doing so
+would allow the caller to supply an arbitrary client-controlled ID and read any record in
+the database with `sudo()`, bypassing the "RM See Own" rule entirely. The strict read rule
+continues to apply on every subsequent request — the reassigning RM loses access to the
+lead the moment they navigate away, because the rule checks `user_id` at read time and
+`user_id` no longer matches.
 
 ### Alternative approaches considered
 

--- a/custom_addons/leads/docs/orm-overrides.md
+++ b/custom_addons/leads/docs/orm-overrides.md
@@ -1,0 +1,320 @@
+# ORM Overrides: `leads` Module
+
+- Module: leads
+- Version documented: 1.5.0
+- Last updated: 2026-04-13
+- Status: Current
+- Scope: All `create`, `write`, `web_save`, and `_search` overrides in `custom_addons/leads/`
+
+---
+
+## Overview
+
+This document records every ORM method override in the `leads` module: what was changed,
+why the standard Odoo behaviour was insufficient, and what failure the override prevents.
+
+Each section covers one override. The sections are ordered by model, then by method.
+
+---
+
+## 1. `leads.new` — `create()`
+
+**File:** `models/new_portal_leads.py`
+
+### What it does
+
+Intercepts every new `leads.new` record before it is written to the database and performs
+four operations in sequence:
+
+1. **Phone normalisation.** Calls `_standardize_phone()` to strip non-numeric characters,
+   remove the leading `91` country code if present, and keep a 10-digit number.
+   Applied to every lead regardless of source.
+
+2. **Source resolution.** If `source_id` is not supplied but a `portal_name` string is
+   present (legacy field from Housing.com/MagicBricks imports), the override calls
+   `_get_or_create_source()` to find or create the matching `lead.source` record and
+   fills `source_id`. A lead without a source is rejected with a `ValidationError`.
+
+3. **Duplicate detection (automated leads only).** For leads created by cron (context key
+   `automated_lead_creation=True`), the override calls `_compute_duplicate_domain()` to
+   build a domain matching same phone + same resolved property within 180 days.
+   If a match exists the lead is silently dropped (returns without creating). This guard
+   runs only for automated leads; manually created leads raise a `ValidationError` so the
+   RM sees the conflict explicitly.
+
+4. **Bus notification.** After successfully creating the record, emits a `bus.bus`
+   notification on channel `"leads.new"` so connected list-view clients reload instantly
+   without a full browser refresh.
+
+### Why the override is needed
+
+- Odoo's standard `create()` does not normalise phone numbers. Without normalisation, the
+  same phone number arrives in at least four forms (`9198765 43210`, `+919876543210`,
+  `9876543210`, `98765 43210`), all treated as distinct, and duplicates are never caught.
+
+- The duplicate guard cannot be a `@api.constrains` because constraints fire after the
+  write and the cron wants a silent no-op drop, not a rollback and error.
+
+- Bus notification in `create()` matches the notification in `write()` so the list view
+  stays live for both new arrivals and status changes without polling.
+
+### Key implementation detail — `mail_create_nolog`
+
+The `super().create()` call is invoked on `self.with_context(mail_create_nolog=True)` to
+suppress the automatic "Record created" chatter entry. The context must be set on `self`
+before `super()` is called. Calling `super().with_context().create()` would resolve back
+to this override and recurse infinitely.
+
+```python
+new_leads = super(
+    NewPortalLead,
+    self.with_context(mail_create_nolog=True),
+).create(normalized_vals_list)
+```
+
+---
+
+## 2. `leads.new` — `write()`
+
+**File:** `models/new_portal_leads.py`
+
+### What it does
+
+Intercepts every field update on an existing `leads.new` record and performs two
+operations after the standard write:
+
+1. **First-contact timestamp.** When `current_status` changes to any value other than
+   `"lead"` and `first_contact_datetime` is still empty, the override stamps the current
+   time. This records the exact moment an RM first meaningfully interacted with the lead
+   (moved it out of the "just arrived" state).
+
+2. **Bus notification with silent-field guard.** Emits a `bus.bus` notification so
+   connected list-view clients reload. Writes that touch only the set
+   `{"first_contact_datetime", "is_webhook_sent", "process_notes"}` are skipped —
+   these are internal bookkeeping fields with no visible effect on the list view, and
+   emitting a notification for them would trigger an unnecessary full reload on every
+   connected client.
+
+### Why the override is needed
+
+- `first_contact_datetime` cannot be a `related` or `compute` field because it must
+  record a point in time, not reflect the current value of another field.
+
+- Without the silent-field guard, the webhook cron (`_cron_send_new_lead_webhooks`)
+  sets `is_webhook_sent = True` on hundreds of leads per batch, firing hundreds of
+  bus notifications and causing every connected RM to reload their list view mid-work.
+
+### Critical: avoiding recursive bus notifications
+
+The timestamp stamp calls `super(NewPortalLead, leads_to_stamp).write(...)` rather than
+`leads_to_stamp.write(...)`. This bypasses the override so the inner write does not fire
+a second bus notification. If `leads_to_stamp.write()` were called instead:
+
+1. Inner write enters this override → `super().write()` → fires bus notification #1.
+2. Outer write resumes → fires bus notification #2.
+
+Two notifications trigger two simultaneous `_webReadGroup` reloads. The first reload
+destroys the OWL component while the second is still resolving, producing an
+`UncaughtPromiseError: Component is destroyed` in the browser console. This was a
+confirmed production bug affecting RMs that changed `current_status` on fresh leads.
+
+---
+
+## 3. `leads.new` — `web_save()`
+
+**File:** `models/new_portal_leads.py`
+
+### What it does
+
+Intercepts the save-and-read-back cycle that the Odoo web client performs when a user
+saves a form. When the save is a **lead reassignment** (i.e. `user_id` is in `vals` and
+it is changing to a different user), the override performs the write normally but reads
+the record back using `sudo()` to bypass the record rule.
+
+For all other saves it delegates to the standard `super().web_save()` unchanged.
+
+### Why the override is needed
+
+The `ir.rule` "New Leads: RM See Own" restricts reads to `[('user_id', '=', user.id)]`.
+
+The sequence of operations in a standard `web_save` is:
+
+1. `self.write(vals)` — succeeds, because at write-time `user_id` still equals
+   the current RM (record rules are evaluated against the pre-write values).
+2. `self.web_read(specification)` — fails with an access error, because `user_id`
+   now points to the new RM.
+
+The result in the browser is a 200 response containing an access-denied error message,
+which the web client displays as a pop-up notification. The lead was successfully
+reassigned (the write did go through) but the UI shows an error, confusing the RM.
+
+**Why `sudo()` here is safe and not a security hole:** `sudo()` applies only to the
+confirmation read that returns data already visible to the RM (they just edited the record).
+The strict read rule continues to apply on every subsequent request — the reassigning RM
+loses access to the lead the moment they navigate away, because the rule checks `user_id`
+at read time and `user_id` no longer matches.
+
+### Alternative approaches considered
+
+| Approach | Problem |
+|---|---|
+| Widen the record rule using `write_uid = user.id` | `write_uid` persists indefinitely on the record. Every lead an RM ever touched would remain visible to them forever, making the "RM See Own" rule meaningless. |
+| Split into separate read/write rules with `write_uid` on the read rule | Same leakage problem — `write_uid` does not reset after the RM loses ownership. |
+| Catch the access error client-side and dismiss it | The error is real from Odoo's perspective; dismissing it hides a symptom rather than fixing the cause. |
+
+---
+
+## 4. `lead.olx.account` — `write()`
+
+**File:** `models/lead_olx_account.py`
+
+### What it does
+
+Before delegating to the standard write, checks whether `login` is being changed.
+If it is, migrates the stored password from the old `ir.config_parameter` key
+(`olx.account.<old_login>.password`) to the new key (`olx.account.<new_login>.password`)
+and clears the old key.
+
+### Why the override is needed
+
+OLX account passwords are never stored in the database column. The `password` field is
+a non-stored compute field — all writes go to `ir.config_parameter` via the
+`_inverse_password()` method, keyed by the account's `login` value.
+
+If an admin corrects a login (e.g. fixes a typo in the phone number), the key in
+`ir.config_parameter` no longer matches the new login. The next OLX poll would fail
+silently with "No password configured for account X", with no visible indication that
+the password was simply stored under the old key.
+
+This override ensures login edits are always safe — the password follows the login
+automatically.
+
+### What happens when the new key already has a value
+
+The override only migrates if the old key has a value. It does not overwrite an existing
+password stored under the new key; this is intentional to avoid clobbering a deliberately
+set password if an admin re-types a login that already existed.
+
+---
+
+## 5. `property.base` — `_search()`
+
+**File:** `models/property_base_extend.py`
+
+### What it does
+
+Injects an additional domain filter `[('rm_user_id', '=', user.id)]` into every
+`_search()` call when both of the following are true:
+
+- The context key `properties_module_view` is present (set by every action in the
+  Properties module).
+- The current user is in `properties.group_property_rm` but not in
+  `properties.group_property_manager`.
+
+For all other contexts (lead forms, domain searches, scheduled jobs) the override passes
+through to `super()` with no additional filter.
+
+### Why the override is needed
+
+Two conflicting requirements exist for `property.base` reads:
+
+| Context | Required behaviour |
+|---|---|
+| Properties module list view | RM sees only their own properties |
+| Lead form `property_base_id` field | RM sees all properties (to select a recommended property owned by a different RM) |
+
+The `ir.rule` in the leads module (`rule_property_base_leads_rm_read_all`) grants
+`[(1,'=',1)]` (read all) to `leads.group_lead_score_rm`. Odoo ORs rules across groups,
+so any RM who is in both the properties RM group and the leads RM group can read all
+property records — which is correct for lead forms but wrong for the Properties list view.
+
+Adding `properties_module_view` as a context key on module actions, then detecting it
+here, restores the list-view restriction without breaking cross-RM reads anywhere else.
+
+**Why `_search()` instead of a domain on the field or an additional rule:**
+A domain on the Many2one field only affects the dropdown picker, not `search()` calls.
+An additional `ir.rule` with context detection is not possible in standard Odoo — rules
+cannot inspect `self.env.context`. `_search()` can.
+
+---
+
+## 6. `property.base` — `write()`
+
+**File:** `models/property_base_extend.py`
+
+### What it does
+
+After the standard write, checks whether any of the four portal ID fields
+(`magicbricks_id`, `ninety_nine_acres_id`, `housing_id`, `olx_id`) were updated.
+For each that was, searches for `leads.new` records that arrived with a matching
+`portal_name` + `portal_property_id` but have `property_base_id = False`
+(unlinked leads). For each match, sets `property_base_id` and reassigns `user_id`
+to the property's RM (falls back to admin if none is set).
+
+### Why the override is needed
+
+Portal leads arrive before the property record is set up, or before the correct portal
+ID is entered. In this scenario:
+
+1. Lead arrives with `portal_name = "MagicBricks"`, `portal_property_id = "MB9871234"`.
+2. No `property.base` record has `magicbricks_id = "MB9871234"` yet.
+3. Lead is created with `property_base_id = False`, assigned to the default RM.
+4. Later, someone enters `MB9871234` in the MagicBricks ID field on the property.
+5. This override fires, finds the lead, sets `property_base_id`, and reassigns the RM.
+
+Without this retroactive relinking, leads permanently stay with the wrong RM and
+lose their property association unless someone manually corrects them.
+
+---
+
+## 7. `property.portal.listing` — `create()` and `write()`
+
+**File:** `models/property_base_extend.py` — class `PropertyPortalListingLeadRelink`
+
+### What it does
+
+After every `create()` of a `property.portal.listing` record, and after every `write()`
+that changes `portal_listing_id`, `portal_name`, or `property_base_id`, calls the shared
+helper `_relink_leads_for_listing()` which performs the same unlinked-lead search and
+reassignment described in Override 6.
+
+### Why this is separate from Override 6
+
+`property.base` directly holds field-level portal IDs (`magicbricks_id`, etc.).
+`property.portal.listing` is the join table that maps a portal listing ID to a
+`property.base` record — it is a separate model with its own create/write lifecycle.
+Both paths need to trigger relinking because either can be the one that establishes
+the match:
+
+- A lead arrives and the portal ID already exists on `property.base` directly → Override 6.
+- A lead arrives and the portal ID is added via a new `property.portal.listing` row → Override 7.
+
+### `write()` pre-capture pattern
+
+The `write()` override captures the old values of the three relevant fields before calling
+`super()`:
+
+```python
+old_state = {
+    rec.id: (rec.portal_name, rec.portal_listing_id, rec.property_base_id)
+    for rec in self
+}
+result = super().write(vals)
+```
+
+This is necessary because after `super().write()`, `self` reflects the new values and the
+comparison `rec.portal_name != old_name` would always be `False` if compared post-write.
+
+---
+
+## Quick Reference Table
+
+| Model | Method | Primary purpose | Production bug it prevents |
+|---|---|---|---|
+| `leads.new` | `create()` | Phone normalisation, duplicate guard, bus notification | Duplicate leads, non-standardised phone numbers breaking dedup |
+| `leads.new` | `write()` | First-contact timestamp, silent-field bus guard | Double bus notification → OWL "Component is destroyed" crash |
+| `leads.new` | `web_save()` | Post-reassignment read-back via `sudo()` | "Access Denied" error after RM reassigns a lead |
+| `lead.olx.account` | `write()` | Config param key migration on login change | Silent "No password" failure after admin edits login |
+| `property.base` | `_search()` | List-view restriction via context key | RMs seeing all properties in Properties module list |
+| `property.base` | `write()` | Retroactive lead relink when portal ID fields change | Leads permanently stuck with wrong RM/no property |
+| `property.portal.listing` | `create()` + `write()` | Retroactive lead relink when listing is created/updated | Leads permanently stuck with wrong RM/no property |

--- a/custom_addons/leads/models/new_portal_leads.py
+++ b/custom_addons/leads/models/new_portal_leads.py
@@ -712,43 +712,6 @@ class NewPortalLead(models.Model):
             }
             self.env["bus.bus"]._sendone(channel, notification_type, message)
 
-    def write(self, vals):
-        """
-        Override write to automatically log 'first_contact_datetime'
-        AND to send a bus notification.
-        """
-
-        leads_to_stamp = self.env["leads.new"]
-        first_contact_time = False
-        if "current_status" in vals and vals["current_status"] != "lead":
-            leads_to_stamp = self.filtered(lambda r: not r.first_contact_datetime)
-            if leads_to_stamp:
-                first_contact_time = fields.Datetime.now()
-
-        res = super().write(vals)
-
-        if leads_to_stamp and first_contact_time:
-            # Bypass the override so this silent internal write does not
-            # fire a second bus notification, which would trigger a second
-            # grouped list reload on every connected client and cause an
-            # OWL "Component is destroyed" race condition.
-            super(NewPortalLead, leads_to_stamp).write(
-                {"first_contact_datetime": first_contact_time}
-            )
-
-        # Skip bus notification for internal-only field updates that have
-        # no visible effect on the list/form (webhook flag, process notes).
-        _SILENT_FIELDS = frozenset({"first_contact_datetime", "is_webhook_sent", "process_notes"})
-        if set(vals.keys()) - _SILENT_FIELDS:
-            channel = "leads.new"
-            notification_type = "bus_notification"
-            message = {
-                "ids": self.ids,
-                "model": "leads.new",
-                "event": "write",
-            }
-            self.env["bus.bus"]._sendone(channel, notification_type, message)
-
         return res
 
     def web_save(self, vals, specification, next_id=None):
@@ -771,8 +734,11 @@ class NewPortalLead(models.Model):
                 self.write(vals)
             else:
                 self = self.create(vals)
-            if next_id:
-                self = self.browse(next_id)
+            # next_id is intentionally ignored here. Applying it and then reading
+            # with sudo() would allow the caller to read any leads.new record by
+            # supplying an arbitrary client-controlled ID, bypassing "RM See Own".
+            # sudo() scope is limited strictly to the one record that was just
+            # written (whose user_id no longer matches the current user).
             return self.sudo().with_context(bin_size=True).web_read(specification)
         return super().web_save(vals, specification, next_id=next_id)
 

--- a/custom_addons/leads/models/new_portal_leads.py
+++ b/custom_addons/leads/models/new_portal_leads.py
@@ -612,7 +612,7 @@ class NewPortalLead(models.Model):
         if resolved_property:
             lead_vals.setdefault("property_base_id", resolved_property.id)
 
-        time_limit = fields.Datetime.now() - timedelta(days=30)
+        time_limit = fields.Datetime.now() - timedelta(days=180)
         if resolved_property:
             domain = [
                 ("phone", "=", phone_clean),
@@ -641,7 +641,7 @@ class NewPortalLead(models.Model):
         Central Function to create leads.
         Checks for duplicates before creating new lead.
         Preferred duplicate key: same phone + same resolved property_base_id
-        in last 30 days (so multiple portal IDs on the same property don't
+        in last 180 days (so multiple portal IDs on the same property don't
         create duplicates).
 
         Fallback (when no portal-listing mapping exists yet):
@@ -691,23 +691,90 @@ class NewPortalLead(models.Model):
         res = super().write(vals)
 
         if leads_to_stamp and first_contact_time:
-            leads_to_stamp.write(
-                {
-                    "first_contact_datetime": first_contact_time,
-                },
+            # Bypass the override so this silent internal write does not
+            # fire a second bus notification, which would trigger a second
+            # grouped list reload on every connected client and cause an
+            # OWL "Component is destroyed" race condition.
+            super(NewPortalLead, leads_to_stamp).write(
+                {"first_contact_datetime": first_contact_time}
             )
 
-        channel = "leads.new"
-        notification_type = "bus_notification"
-        message = {
-            "ids": self.ids,
-            "model": "leads.new",
-            "event": "write",
-        }
+        # Skip bus notification for internal-only field updates that have
+        # no visible effect on the list/form (webhook flag, process notes).
+        _SILENT_FIELDS = frozenset({"first_contact_datetime", "is_webhook_sent", "process_notes"})
+        if set(vals.keys()) - _SILENT_FIELDS:
+            channel = "leads.new"
+            notification_type = "bus_notification"
+            message = {
+                "ids": self.ids,
+                "model": "leads.new",
+                "event": "write",
+            }
+            self.env["bus.bus"]._sendone(channel, notification_type, message)
 
-        self.env["bus.bus"]._sendone(channel, notification_type, message)
+    def write(self, vals):
+        """
+        Override write to automatically log 'first_contact_datetime'
+        AND to send a bus notification.
+        """
+
+        leads_to_stamp = self.env["leads.new"]
+        first_contact_time = False
+        if "current_status" in vals and vals["current_status"] != "lead":
+            leads_to_stamp = self.filtered(lambda r: not r.first_contact_datetime)
+            if leads_to_stamp:
+                first_contact_time = fields.Datetime.now()
+
+        res = super().write(vals)
+
+        if leads_to_stamp and first_contact_time:
+            # Bypass the override so this silent internal write does not
+            # fire a second bus notification, which would trigger a second
+            # grouped list reload on every connected client and cause an
+            # OWL "Component is destroyed" race condition.
+            super(NewPortalLead, leads_to_stamp).write(
+                {"first_contact_datetime": first_contact_time}
+            )
+
+        # Skip bus notification for internal-only field updates that have
+        # no visible effect on the list/form (webhook flag, process notes).
+        _SILENT_FIELDS = frozenset({"first_contact_datetime", "is_webhook_sent", "process_notes"})
+        if set(vals.keys()) - _SILENT_FIELDS:
+            channel = "leads.new"
+            notification_type = "bus_notification"
+            message = {
+                "ids": self.ids,
+                "model": "leads.new",
+                "event": "write",
+            }
+            self.env["bus.bus"]._sendone(channel, notification_type, message)
 
         return res
+
+    def web_save(self, vals, specification, next_id=None):
+        """
+        Override web_save to handle lead reassignment.
+
+        When user_id is being changed (RM reassigns the lead to another RM),
+        the write succeeds because the record rule is evaluated against the
+        pre-write value (still the current user). However the immediate
+        read-back that web_save performs after the write would fail because
+        user_id now points to the new RM, violating the 'RM See Own' rule.
+
+        Using sudo() only for this one-time confirmation read keeps the strict
+        read rule intact everywhere else — the reassigning RM loses access the
+        moment they navigate away from the record.
+        """
+        reassigning = "user_id" in vals and vals["user_id"] != self.env.uid
+        if reassigning:
+            if self:
+                self.write(vals)
+            else:
+                self = self.create(vals)
+            if next_id:
+                self = self.browse(next_id)
+            return self.sudo().with_context(bin_size=True).web_read(specification)
+        return super().web_save(vals, specification, next_id=next_id)
 
     # --- Lead Processing & Assignment ---
 
@@ -1229,11 +1296,13 @@ class NewPortalLead(models.Model):
                 "lead_id": lead.id,
                 "name": lead.name,
                 "phone": lead.phone,
+                "email": lead.email or False,
                 "source": lead.source_id.name,
                 "portal_property_id": lead.portal_property_id,
+                "project_name": lead.project_name or False,
                 "rm_name": rm_name,
-                # Property Info
-                "property_id": prop_id,
+                # Property Info (property.base — the new canonical model)
+                "property_base_id": prop_id,
                 "property_tag": prop_tag,
                 "property_bhk": prop_bhk,
                 "property_location": prop_location,

--- a/custom_addons/leads/tests/test_portal_lead_duplicate.py
+++ b/custom_addons/leads/tests/test_portal_lead_duplicate.py
@@ -51,7 +51,7 @@ class TestPortalLeadDuplicateDetection(PortalLeadTestCase):
         self.assertTrue(lead2, "Should create lead with different property IDs")
 
     def test_03_duplicate_same_phone_and_property_recent(self):
-        """Same phone + property within 30 days should be duplicate (return False)."""
+        """Same phone + property within 180 days should be duplicate (return False)."""
         # 1. Create Base Lead
         self.env["leads.new"].create_lead_if_not_duplicate(
             {
@@ -73,8 +73,8 @@ class TestPortalLeadDuplicateDetection(PortalLeadTestCase):
         lead2 = self.env["leads.new"].create_lead_if_not_duplicate(lead2_vals)
         self.assertFalse(lead2, "Should NOT create duplicate lead (Recent)")
 
-    def test_04_not_duplicate_after_30_days(self):
-        """Same lead after 30 days should be allowed."""
+    def test_04_not_duplicate_after_180_days(self):
+        """Same lead after 180 days should be allowed."""
         # 1. Create Old Lead
         old_lead = self.env["leads.new"].create_lead_if_not_duplicate(
             {
@@ -85,8 +85,8 @@ class TestPortalLeadDuplicateDetection(PortalLeadTestCase):
             },
         )
 
-        # 2. Force date to 31 days ago via SQL to bypass ORM readonly check
-        old_date = fields.Datetime.now() - timedelta(days=31)
+        # 2. Force date to 181 days ago via SQL to bypass ORM readonly check
+        old_date = fields.Datetime.now() - timedelta(days=181)
         self.env.cr.execute(
             "UPDATE leads_new SET create_date = %s WHERE id = %s",
             (old_date, old_lead.id),
@@ -102,7 +102,7 @@ class TestPortalLeadDuplicateDetection(PortalLeadTestCase):
         }
 
         new_lead = self.env["leads.new"].create_lead_if_not_duplicate(new_lead_vals)
-        self.assertTrue(new_lead, "Should create lead after 30 days expiration")
+        self.assertTrue(new_lead, "Should create lead after 180 days expiration")
 
     def test_05_duplicate_detection_returns_none(self):
         """Duplicate detection should return None and not create a new lead."""

--- a/custom_addons/leads/tests/test_portal_lead_webhook.py
+++ b/custom_addons/leads/tests/test_portal_lead_webhook.py
@@ -67,6 +67,12 @@ class TestPortalLeadWebhook(PortalLeadTestCase):
         self.assertEqual(target_lead_data['property_bhk'], '3 BHK')
         self.assertIn(self.rm_user.name, target_lead_data['rm_name'])
         self.assertEqual(target_lead_data['property_tag'], self.test_property.property_tag)
+        self.assertEqual(target_lead_data['source'], self.source_magicbricks.name,
+                         "Webhook must send source name, not portal listing ID")
+        self.assertIn('email', target_lead_data, "Webhook payload must include email field")
+        self.assertIn('project_name', target_lead_data, "Webhook payload must include project_name field")
+        self.assertEqual(target_lead_data['property_base_id'], self.test_property.id,
+                         "Webhook must send property.base ID under key 'property_base_id', not legacy property.inventory ID")
 
     def test_03_webhook_skips_if_url_not_configured(self):
         """Should skip webhook if URL not configured."""


### PR DESCRIPTION
This pull request introduces several important improvements and fixes to the `leads` module, focusing on duplicate lead detection, webhook payload accuracy, and bus notification logic. The key changes include extending the duplicate detection window from 30 to 180 days, enhancing the webhook payload with additional fields, and refining the bus notification system to avoid unnecessary reloads and errors. Comprehensive documentation of ORM overrides has also been added for clarity and maintainability.

**Lead duplicate detection and handling:**
- Extended the duplicate detection window for leads from 30 days to 180 days in both the backend logic (`_compute_duplicate_domain`, `create_lead_if_not_duplicate`) and the test suite, ensuring that leads with the same phone and property within 180 days are considered duplicates. [[1]](diffhunk://#diff-a549796b5f909f39f40bdfc20e93ee6d93224285e28a9bf627a45cabce3d6a4cL615-R615) [[2]](diffhunk://#diff-a549796b5f909f39f40bdfc20e93ee6d93224285e28a9bf627a45cabce3d6a4cL644-R644) [[3]](diffhunk://#diff-d5a363a641128ac05c22d351cc56f83755712289e56bc1449220cab4296e5529L54-R54) [[4]](diffhunk://#diff-d5a363a641128ac05c22d351cc56f83755712289e56bc1449220cab4296e5529L76-R77) [[5]](diffhunk://#diff-d5a363a641128ac05c22d351cc56f83755712289e56bc1449220cab4296e5529L88-R89) [[6]](diffhunk://#diff-d5a363a641128ac05c22d351cc56f83755712289e56bc1449220cab4296e5529L105-R105)
- Added and updated tests to reflect the new 180-day duplicate window, ensuring correctness and preventing regression. [[1]](diffhunk://#diff-d5a363a641128ac05c22d351cc56f83755712289e56bc1449220cab4296e5529L54-R54) [[2]](diffhunk://#diff-d5a363a641128ac05c22d351cc56f83755712289e56bc1449220cab4296e5529L76-R77) [[3]](diffhunk://#diff-d5a363a641128ac05c22d351cc56f83755712289e56bc1449220cab4296e5529L88-R89) [[4]](diffhunk://#diff-d5a363a641128ac05c22d351cc56f83755712289e56bc1449220cab4296e5529L105-R105)

**Webhook payload improvements:**
- Enhanced the webhook payload sent by `_cron_send_new_lead_webhooks` to include `email`, `project_name`, and to use `property_base_id` instead of the legacy `property_id`, ensuring downstream integrations receive complete and accurate data. [[1]](diffhunk://#diff-a549796b5f909f39f40bdfc20e93ee6d93224285e28a9bf627a45cabce3d6a4cR1299-R1305) [[2]](diffhunk://#diff-22721a792331f52268e190873f413884bab7d0a7fcf2fb5ab27302e833ab2cb8R70-R75)
- Updated webhook tests to assert the presence and correctness of these new fields.

**Bus notification and ORM override logic:**
- Refined the `write()` override for `leads.new` to avoid double bus notifications, preventing OWL component errors and unnecessary client reloads. The override now bypasses itself when stamping `first_contact_datetime` and only sends notifications for user-visible changes.
- Implemented a `web_save()` override to use `sudo()` for the confirmation read after lead reassignment, preventing "Access Denied" errors in the UI while maintaining strict access rules elsewhere.

**Documentation:**
- Added a comprehensive `orm-overrides.md` file documenting all ORM method overrides in the `leads` module, including rationale, implementation details, and production issues addressed.Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
