### PR TITLE
Add compute_sudo and refactor auto-refresh

### DIFF
--- a/custom_addons/leads/models/new_portal_leads.py
+++ b/custom_addons/leads/models/new_portal_leads.py
@@ -215,6 +215,7 @@ class NewPortalLead(models.Model):
         string="Property Tag",
         readonly=True,
         store=True,
+        compute_sudo=True,
     )
 
     base_property_bhk = fields.Char(
@@ -222,6 +223,7 @@ class NewPortalLead(models.Model):
         string="Property BHK",
         readonly=True,
         store=True,
+        compute_sudo=True,
     )
 
     base_property_location = fields.Char(
@@ -229,6 +231,7 @@ class NewPortalLead(models.Model):
         string="Property Location",
         readonly=True,
         store=True,
+        compute_sudo=True,
     )
 
     base_property_city = fields.Char(
@@ -236,6 +239,7 @@ class NewPortalLead(models.Model):
         string="Property City",
         readonly=True,
         store=True,
+        compute_sudo=True,
     )
 
     base_property_owner_name = fields.Char(
@@ -243,6 +247,7 @@ class NewPortalLead(models.Model):
         string="Property Owner",
         readonly=True,
         store=True,
+        compute_sudo=True,
     )
 
     base_property_link = fields.Char(
@@ -250,6 +255,7 @@ class NewPortalLead(models.Model):
         string="Property Link",
         readonly=True,
         store=True,
+        compute_sudo=True,
     )
 
     process_notes = fields.Text("Processing Notes")

--- a/custom_addons/leads/static/src/js/leads_list_controller.js
+++ b/custom_addons/leads/static/src/js/leads_list_controller.js
@@ -8,46 +8,54 @@ import { onWillUnmount } from "@odoo/owl";
 export class LeadsNewListController extends ListController {
     setup() {
         super.setup();
-        this.autoRefreshInterval = null;
+        this._refreshTimeout = null;
+        this._refreshInProgress = false;
         this.isDestroyed = false;
-        
-        // Use Owl's onWillUnmount hook
+
         onWillUnmount(() => {
             this.isDestroyed = true;
-            if (this.autoRefreshInterval) {
-                clearInterval(this.autoRefreshInterval);
-                this.autoRefreshInterval = null;
+            if (this._refreshTimeout) {
+                clearTimeout(this._refreshTimeout);
+                this._refreshTimeout = null;
             }
         });
-        
-        this.startAutoRefresh();
+
+        this._scheduleNextRefresh();
     }
 
-    startAutoRefresh() {
-        // Clear any existing interval
-        if (this.autoRefreshInterval) {
-            clearInterval(this.autoRefreshInterval);
+    _scheduleNextRefresh() {
+        if (this.isDestroyed) return;
+
+        // Schedule the next refresh AFTER the previous one completes.
+        // Using setTimeout instead of setInterval prevents overlapping loads.
+        this._refreshTimeout = setTimeout(() => this._doRefresh(), 50000);
+    }
+
+    async _doRefresh() {
+        if (
+            this.isDestroyed ||
+            this._refreshInProgress ||
+            document.visibilityState !== "visible" ||
+            !this.model?.root ||
+            this.model.root.editedRecord
+        ) {
+            // Skip this tick but schedule the next one.
+            this._scheduleNextRefresh();
+            return;
         }
 
-        // Set auto-refresh interval (50 second)
-        const refreshInterval = 50000; // 50 second in milliseconds
-        
-        this.autoRefreshInterval = setInterval(() => {
-            // Only refresh if component is not destroyed, view is visible and not in edit mode
-            if (!this.isDestroyed && 
-                document.visibilityState === "visible" && 
-                this.model?.root && 
-                !this.model.root.editedRecord) {
-                try {
-                    this.model.root.load();
-                } catch (error) {
-                    // Component was destroyed during load, clear interval
-                    console.log("Auto-refresh stopped due to component destruction");
-                    clearInterval(this.autoRefreshInterval);
-                    this.autoRefreshInterval = null;
-                }
+        this._refreshInProgress = true;
+        try {
+            await this.model.root.load();
+        } catch {
+            // Component was destroyed during load, or network error — ignore.
+        } finally {
+            this._refreshInProgress = false;
+            // Only schedule the next refresh if the component is still alive.
+            if (!this.isDestroyed) {
+                this._scheduleNextRefresh();
             }
-        }, refreshInterval);
+        }
     }
 }
 


### PR DESCRIPTION
Enable compute_sudo=True on several stored readonly property fields (base_property_tag, base_property_bhk, base_property_location, base_property_city, base_property_owner_name, base_property_link) so their compute methods run with elevated rights.

Refactor the leads list auto-refresh to avoid overlapping loads: replace interval-based refresh with a sequential setTimeout scheduler, introduce _refreshTimeout and _refreshInProgress flags, skip refresh when the view is hidden or a record is being edited, and clear the timeout on unmount. Keeps a 50s delay between refreshes and handles errors/destruction gracefully.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
