### PR TITLE
Refactor lead import wizard and enhance site visit handling

### DIFF
--- a/custom_addons/leads/controllers/API_DOCUMENTATION.md
+++ b/custom_addons/leads/controllers/API_DOCUMENTATION.md
@@ -168,8 +168,16 @@ These values appear in `current_status` fields across all endpoints.
 
 ### Feedback fields
 
-`feedback_general` and `feedback_site_visit_done` contain feedback selected by the RM, or `null`.
-`feedback_general` is for feedback given before site visit done, mostly stored when site visit scheduled stage is present and `feedback_site_visit_done` is after the site visit has been done.
+Site-visit endpoints populate feedback from the `lead.site.visit` model:
+
+| Response field              | Source                                  | Description |
+|-----------------------------|-----------------------------------------|-------------|
+| `feedback_general`          | `visit.feedback_option_id.code`         | Feedback code for non-completed visits (cancelled / no-show reason) |
+| `feedback_site_visit_done`  | `visit.feedback_option_id.code`         | Feedback code when the visit is completed |
+| `remarks`                   | `visit.feedback_note`                   | Free-text note recorded by the RM |
+
+Both `feedback_general` and `feedback_site_visit_done` are populated from the same underlying field (`feedback_option_id.code`) — the response key used depends on which bucket the visit is classified into. Values are feedback option codes (e.g. `"negotiation_started"`, `"buyer_cancelled_interest"`).
+
 ---
 
 ## 5. Endpoints — Buyer
@@ -177,6 +185,8 @@ These values appear in `current_status` fields across all endpoints.
 ### 5.1 `GET /api/track/lead/site-visits`
 
 Returns all site visits for a buyer's phone number, classified into four timeline buckets.
+
+Data is read directly from the `lead.site.visit` model (not from the snapshot fields on `leads.new`), so feedback, cancellation reasons, and no-show statuses are always accurate.
 
 **Auth required:** Yes (`X-API-Key`)
 
@@ -206,41 +216,45 @@ Returns all site visits for a buyer's phone number, classified into four timelin
 
 #### Bucket classification logic
 
-| Bucket             | Condition                                                                                                          | Sort order |
-|--------------------|---------------------------------------------------------------------------------------------------------------------|------------|
-| `upcoming`         | `current_status = "site_visit_scheduled"` AND `site_visit_datetime` is in the future                              | ASC (soonest first) |
-| `pending_feedback` | `current_status = "site_visit_scheduled"` AND `site_visit_datetime` is in the past AND `feedback_general` is null/empty/`"other"` | ASC        |
-| `cancelled`        | `current_status = "site_visit_scheduled"` AND `site_visit_datetime` is in the past AND `feedback_general` is present | DESC (most recent first) |
-| `completed`        | `current_status = "site_visit_done"`                                                                              | DESC       |
+Classification is driven by the **status-type flags** on `lead.site.visit.status`, not by the `current_status` string snapshot on `leads.new`.
 
-> **Reschedules:** When a visit is rescheduled via `lead.site.visit`, the original visit is superseded and a new visit is created with `status="scheduled"`. `lead.site.visit._sync_inquiry_snapshot` writes `current_status="site_visit_scheduled"` with the new date to the inquiry snapshot, so the rescheduled visit surfaces in `upcoming` if its date is in the future. Records from before v1.3 with `current_status="rescheduled"` are not returned by this endpoint.
+| Bucket             | Status condition                                         | Date condition                  | Sort order |
+|--------------------|----------------------------------------------------------|---------------------------------|------------|
+| `upcoming`         | `status.is_scheduled` OR `status.is_rescheduled`         | `site_visit_datetime` in future | ASC (soonest first) |
+| `pending_feedback` | `status.is_scheduled` OR `status.is_rescheduled`         | `site_visit_datetime` in past   | ASC (oldest first) |
+| `cancelled`        | `status.is_cancelled` OR `status.is_no_show`             | —                               | DESC (most recent first) |
+| `completed`        | `status.is_completed`                                    | —                               | DESC       |
+
+> **Reschedules:** When a visit is rescheduled, the original visit is superseded and a new `lead.site.visit` record is created with `status="scheduled"` and the new datetime. The new visit appears in `upcoming` if its date is in the future. The superseded visit is excluded from results.
+>
+> **No-show:** A visit marked as "Did Not Show Up" is classified as `cancelled`, not `pending_feedback`. This was not correctly handled before v2.0.
 
 #### Visit object fields
 
 All buckets include this base set:
 
-| Field                  | Type              | Description                                               |
-|------------------------|-------------------|-----------------------------------------------------------|
-| `inquiry_type`         | `string`          | `"primary"` or `"recommended"`                            |
-| `lead_id`              | `integer`         | ID of the parent `leads.new` record                       |
-| `lead_name`            | `string \| null`  | Buyer name                                                |
-| `source`               | `string \| null`  | Lead source of origin (e.g. `"MagicBricks"`, `"99acres"`) |
-| `property_tag`         | `string \| null`  | Unique property identifier tag                            |
-| `property_bhk`         | `string \| null`  | Property size (e.g. `"2BHK"`)                             |
-| `property_location`    | `string \| null`  | Locality / micro-location                                 |
-| `property_city`        | `string \| null`  | City                                                      |
-| `site_visit_datetime`  | `string \| null`  | ISO 8601 datetime of the visit                            |
-| `site_visit_date`      | `string \| null`  | Date-only string (`YYYY-MM-DD`)                           |
-| `current_status`       | `string \| null`  | See [Lead Status Reference](#4-lead-status-reference)     |
-| `remarks`              | `string \| null`  | RM notes                                                  |
+| Field                  | Type              | Source                              | Description                                               |
+|------------------------|-------------------|-------------------------------------|-----------------------------------------------------------|
+| `inquiry_type`         | `string`          | `leads.new.inquiry_type`            | `"primary"` or `"recommended"`                            |
+| `lead_id`              | `integer`         | `leads.new.id`                      | ID of the parent `leads.new` record                       |
+| `lead_name`            | `string \| null`  | `leads.new.name`                    | Buyer name                                                |
+| `source`               | `string \| null`  | `leads.new.source_id.name`          | Lead source of origin (e.g. `"MagicBricks"`, `"99acres"`) |
+| `property_tag`         | `string \| null`  | `lead.site.visit.property_base_id`  | Unique property identifier tag                            |
+| `property_bhk`         | `string \| null`  | `property_base.bhk`                 | Property size (e.g. `"2BHK"`)                             |
+| `property_location`    | `string \| null`  | `property_base.location`            | Locality / micro-location                                 |
+| `property_city`        | `string \| null`  | `property_base.city`                | City                                                      |
+| `site_visit_datetime`  | `string \| null`  | `lead.site.visit.scheduled_datetime`| ISO 8601 datetime of the visit                            |
+| `site_visit_date`      | `string \| null`  | `lead.site.visit.scheduled_date`    | Date-only string (`YYYY-MM-DD`)                           |
+| `current_status`       | `string \| null`  | Derived from `status_id` flags      | `"site_visit_scheduled"` or `"site_visit_done"` (for display only — use bucket name for routing) |
+| `remarks`              | `string \| null`  | `lead.site.visit.feedback_note`     | Free-text RM note                                         |
 
 **Additional fields by bucket:**
 
-| Bucket             | Extra fields                                                                 |
-|--------------------|------------------------------------------------------------------------------|
-| `pending_feedback` | `note` — `Visit date has passed — awaiting RM feedback`                      |
-| `cancelled`        | `feedback_general`, `note` — `Visit did not occur due to buyer status`       |
-| `completed`        | `feedback_site_visit_done`; `remarks` only when `feedback_site_visit_done = "other"` |
+| Bucket             | Extra fields                                                                                  |
+|--------------------|-----------------------------------------------------------------------------------------------|
+| `pending_feedback` | `note` — `"Visit date has passed — awaiting RM feedback"`                                    |
+| `cancelled`        | `feedback_general` (`visit.feedback_option_id.code`), `note` — `"Visit did not occur due to buyer status"` |
+| `completed`        | `feedback_site_visit_done` (`visit.feedback_option_id.code`)                                  |
 
 #### Success example
 
@@ -569,24 +583,24 @@ All site visits for a seller's properties, classified into four timeline buckets
 }
 ```
 
-Bucket classification and sort order are identical to the [buyer site-visits endpoint](#51-get-apitrackleadsite-visits).
+Bucket classification and sort order are identical to the [buyer site-visits endpoint](#51-get-apitrackleadsite-visits). Data is read directly from `lead.site.visit` — not from the snapshot fields on `leads.new`.
 
 #### Visit object (seller perspective)
 
-> Seller records expose `lead_name` and `lead_phone` instead of `lead_id`. They include inquiry type in `source` (`primary`/`recommended`) and do not include `property_city`.
+> Seller records expose `lead_name` and `lead_phone` instead of `lead_id`. The `source` field carries the inquiry type (`"primary"`/`"recommended"`). Both primary and recommended inquiries managed via `leads.new` + `lead.site.visit` are returned. Legacy `lead.property.interest` records (pre-visit-model) are returned on the legacy snapshot path if they have a visit date.
 
-| Field                  | Type              | Description                           |
-|------------------------|-------------------|---------------------------------------|
-| `source`               | `string`          | `"primary"` or `"recommended"`        |
-| `lead_name`            | `string \| null`  | Buyer name                            |
-| `lead_phone`           | `string \| null`  | Buyer phone number                    |
-| `property_tag`         | `string \| null`  | Property tag                          |
-| `property_bhk`         | `string \| null`  | Property size                         |
-| `property_location`    | `string \| null`  | Locality                              |
-| `site_visit_datetime`  | `string \| null`  | ISO 8601 datetime                     |
-| `site_visit_date`      | `string \| null`  | Date-only string                      |
-| `current_status`       | `string \| null`  | Lead status                           |
-| `remarks`              | `string \| null`  | RM notes                              |
+| Field                  | Type              | Source                                | Description                           |
+|------------------------|-------------------|---------------------------------------|---------------------------------------|
+| `source`               | `string`          | `leads.new.inquiry_type`              | `"primary"` or `"recommended"`        |
+| `lead_name`            | `string \| null`  | `leads.new.name`                      | Buyer name                            |
+| `lead_phone`           | `string \| null`  | `leads.new.phone`                     | Buyer phone number                    |
+| `property_tag`         | `string \| null`  | `lead.site.visit.property_base_id`    | Property tag                          |
+| `property_bhk`         | `string \| null`  | `property_base.bhk`                   | Property size                         |
+| `property_location`    | `string \| null`  | `property_base.location`              | Locality                              |
+| `site_visit_datetime`  | `string \| null`  | `lead.site.visit.scheduled_datetime`  | ISO 8601 datetime                     |
+| `site_visit_date`      | `string \| null`  | `lead.site.visit.scheduled_date`      | Date-only string                      |
+| `current_status`       | `string \| null`  | Derived from `status_id` flags        | `"site_visit_scheduled"` or `"site_visit_done"` |
+| `remarks`              | `string \| null`  | `lead.site.visit.feedback_note`       | Free-text RM note                     |
 
 Additional per-bucket fields are the same as the buyer endpoint (`note`, `feedback_general`, `feedback_site_visit_done`).
 

--- a/custom_addons/leads/controllers/buyer/site_visits.py
+++ b/custom_addons/leads/controllers/buyer/site_visits.py
@@ -105,187 +105,94 @@ from ..shared.response_utils import error_response, success_response
 
 _logger = logging.getLogger(__name__)
 
-# Only statuses produced by the lead.site.visit model are accepted.
-# "rescheduled" was removed in v1.3.1: the visit model never writes it.
-_VISIT_STATUSES = {"site_visit_scheduled", "site_visit_done"}
 
-_EMPTY_FEEDBACK = {None, "", "other", False}
-
-
-def _classify_visit(
-    current_status: str,
-    site_visit_date: datetime | None,
-    now: datetime,
-    feedback_general: str | None,
-) -> str:
+def _get_latest_active_visit(lead):
     """
-     Determine which bucket a visit record belongs to.
+    Return the latest non-superseded lead.site.visit for this inquiry.
+
+    "Superseded" visits are the old, now-closed leg of a reschedule chain.
+    They carry historical context but do not represent a current appointment.
+    We filter them out so the API always reflects the actual current state.
+    """
+    return lead.sudo().site_visit_ids.filtered(
+        lambda v: v.status_id.code != "superseded"
+    )[:1]
+
+
+def _classify_visit(visit, now: datetime) -> str:
+    """
+    Classify a lead.site.visit record into an API bucket.
 
     Returns one of: "upcoming" | "pending_feedback" | "cancelled" | "completed"
 
-    Both new and rescheduled visits appear as "site_visit_scheduled" in the
-    snapshot (written by lead.site.visit._sync_inquiry_snapshot). A reschedule
-    supersedes the original visit and writes a new date, so rescheduled visits
-    land in "upcoming" if the new date is in the future.
+    Relies on the status-type flags on lead.site.visit.status rather than
+    comparing string codes.  This is robust to status name changes and covers
+    all terminal states correctly — including no-show, which the old snapshot-
+    based approach could not represent at all.
     """
-    if current_status == "site_visit_done":
+    s = visit.status_id
+    if s.is_completed_status:
         return "completed"
-
-    if current_status == "site_visit_scheduled":
-        if site_visit_date > now:
-            return "upcoming"
-
-        if feedback_general in _EMPTY_FEEDBACK:
-            return "pending_feedback"
+    if s.is_cancelled_status or s.is_no_show_status:
         return "cancelled"
-
+    # Scheduled or rescheduled: gate on future/past datetime
+    if visit.scheduled_datetime and visit.scheduled_datetime > now:
+        return "upcoming"
     return "pending_feedback"
 
 
-def _build_base_record(
-    source: str,
-    lead_id: int,
-    lead_name,
-    lead_source,
-    prop,
-    site_visit_date,
-    site_visit_date_only,
-    current_status: str,
-    remarks,
-) -> dict:
-    """Fields present in every bucket."""
-    return {
-        "inquiry_type": source,
-        "lead_id": lead_id,
-        "lead_name": lead_name or None,
-        "source": lead_source or None,
+def _visit_from_lead(lead, visit, now: datetime) -> tuple[str, datetime, dict]:
+    """
+    Build (bucket, sort_key, record_dict) for a leads.new inquiry and its
+    latest lead.site.visit record.
+
+    Reads directly from lead.site.visit to avoid the stale snapshot problem:
+      - feedback_option_id / feedback_note are never written back to leads.new
+        by _sync_inquiry_snapshot, so reading leads.new.feedback_* always
+        returns empty for visits managed through the new visit model.
+      - cancelled / no-show statuses are not synced to leads.new.current_status
+        at all, so reading that field misclassifies them as pending_feedback.
+    """
+    bucket = _classify_visit(visit, now)
+    prop = visit.property_base_id
+    s = visit.status_id
+
+    # Map to the legacy current_status strings for response backward compat.
+    # Clients key on the bucket name for routing, but current_status is kept
+    # for informational display.
+    current_status_str = "site_visit_done" if s.is_completed_status else "site_visit_scheduled"
+
+    feedback_code = visit.feedback_option_id.code or None
+    feedback_note = visit.feedback_note or None
+
+    record = {
+        "inquiry_type": lead.inquiry_type or "primary",
+        "lead_id": lead.id,
+        "lead_name": lead.name or None,
+        "source": lead.source_id.name if lead.source_id else None,
         "property_tag": prop.property_tag if prop else None,
         "property_bhk": prop.bhk if prop else None,
         "property_location": prop.location if prop else None,
         "property_city": prop.city if prop else None,
         "site_visit_datetime": (
-            site_visit_date.isoformat() if site_visit_date else None
+            visit.scheduled_datetime.isoformat() if visit.scheduled_datetime else None
         ),
         "site_visit_date": (
-            site_visit_date_only.isoformat() if site_visit_date_only else None
+            visit.scheduled_date.isoformat() if visit.scheduled_date else None
         ),
-        "current_status": current_status or None,
-        "remarks": remarks or None,
+        "current_status": current_status_str,
+        "remarks": feedback_note,
     }
 
-
-def _apply_bucket_fields(
-    record: dict,
-    bucket: str,
-    feedback_general: str | None,
-    feedback_site_visit_done: str | None,
-    remarks,
-) -> dict:
-    """
-    Add bucket-specific fields to the record in-place and return it.
-
-    pending_feedback — note only; no feedback value since none was logged.
-    cancelled        — feedback_general (the reason) + note.
-    completed        — feedback_site_visit_done always; remarks only when "other".
-    upcoming         — no extra fields.
-    """
     if bucket == "pending_feedback":
         record["note"] = "Visit date has passed — awaiting RM feedback"
-
     elif bucket == "cancelled":
-        record["feedback_general"] = feedback_general
+        record["feedback_general"] = feedback_code
         record["note"] = "Visit did not occur due to buyer status"
-
     elif bucket == "completed":
-        record["feedback_site_visit_done"] = feedback_site_visit_done or None
-        if feedback_site_visit_done == "other":
-            record["remarks"] = remarks or None
-        else:
-            # Keep payload clean — remarks only matter when feedback is "other"
-            record["remarks"] = None
+        record["feedback_site_visit_done"] = feedback_code
 
-    return record
-
-
-def _process_visit(
-    source: str,
-    lead_id: int,
-    lead_name,
-    lead_source,
-    prop,
-    site_visit_date,
-    site_visit_date_only,
-    current_status: str,
-    remarks,
-    feedback_general,
-    feedback_site_visit_done,
-    now: datetime,
-) -> tuple[str, datetime, dict]:
-    """
-    Full pipeline for one record: classify → build base → apply bucket fields.
-    Returns (bucket, sort_key, record_dict).
-    """
-    bucket = _classify_visit(current_status, site_visit_date, now, feedback_general)
-
-    record = _build_base_record(
-        source=source,
-        lead_id=lead_id,
-        lead_name=lead_name,
-        lead_source=lead_source,
-        prop=prop,
-        site_visit_date=site_visit_date,
-        site_visit_date_only=site_visit_date_only,
-        current_status=current_status,
-        remarks=remarks,
-    )
-
-    _apply_bucket_fields(
-        record=record,
-        bucket=bucket,
-        feedback_general=feedback_general,
-        feedback_site_visit_done=feedback_site_visit_done,
-        remarks=remarks,
-    )
-
-    return bucket, site_visit_date, record
-
-
-def _visit_from_primary(lead, now: datetime) -> tuple[str, datetime, dict]:
-    return _process_visit(
-        source="primary",
-        lead_id=lead.id,
-        lead_name=lead.name,
-        lead_source=lead.source_id.name,
-        prop=lead.property_base_id,
-        site_visit_date=lead.site_visit_date,
-        site_visit_date_only=lead.site_visit_date_only,
-        current_status=lead.current_status,
-        remarks=lead.remarks,
-        feedback_general=lead.feedback_general,
-        feedback_site_visit_done=lead.feedback_site_visit_done,
-        now=now,
-    )
-
-
-def _visit_from_interest(
-    interest,
-    parent_lead,
-    now: datetime,
-) -> tuple[str, datetime, dict]:
-    return _process_visit(
-        source="recommended",
-        lead_id=parent_lead.id,
-        lead_name=parent_lead.name,
-        lead_source=parent_lead.source_id.name,
-        prop=interest.property_base_id,
-        site_visit_date=interest.site_visit_date,
-        site_visit_date_only=interest.site_visit_date_only,
-        current_status=interest.current_status,
-        remarks=interest.remarks,
-        feedback_general=interest.feedback_general,
-        feedback_site_visit_done=interest.feedback_site_visit_done,
-        now=now,
-    )
+    return bucket, visit.scheduled_datetime, record
 
 
 class BuyerSiteVisitsController(http.Controller):
@@ -324,19 +231,16 @@ class BuyerSiteVisitsController(http.Controller):
         }
 
         for lead in leads:
-            # ── Primary lead site visit ───────────────────────────────────────
-            if lead.site_visit_date and lead.current_status in _VISIT_STATUSES:
-                bucket, sort_key, record = _visit_from_primary(lead, now)
-                buckets[bucket].append((sort_key, record))
-
-            # ── Recommended property site visits on this lead ─────────────────
-            for interest in lead.interest_ids:
-                if (
-                    interest.site_visit_date
-                    and interest.current_status in _VISIT_STATUSES
-                ):
-                    bucket, sort_key, record = _visit_from_interest(interest, lead, now)
-                    buckets[bucket].append((sort_key, record))
+            # Covers both primary and recommended inquiries: each leads.new
+            # record (regardless of inquiry_type) owns its own site visits
+            # through the lead.site.visit model.  Legacy lead.property.interest
+            # recommended visits are not shown here — they predate the visit
+            # model and have no lead.site.visit records.
+            visit = _get_latest_active_visit(lead)
+            if not visit:
+                continue
+            bucket, sort_key, record = _visit_from_lead(lead, visit, now)
+            buckets[bucket].append((sort_key, record))
 
         # ── Sort each bucket ──────────────────────────────────────────────────
         # upcoming         → soonest first (ascending)

--- a/custom_addons/leads/controllers/seller/site_visits.py
+++ b/custom_addons/leads/controllers/seller/site_visits.py
@@ -117,9 +117,8 @@ from ..shared.response_utils import error_response, success_response
 
 _logger = logging.getLogger(__name__)
 
-# Only statuses produced by the lead.site.visit model are accepted.
-# "rescheduled" was removed in v1.3.1: the visit model never writes it.
-_VISIT_STATUSES = {"site_visit_scheduled", "site_visit_done"}
+# Only statuses used by the legacy lead.property.interest snapshot path.
+_LEGACY_VISIT_STATUSES = {"site_visit_scheduled", "site_visit_done"}
 
 # feedback_general values treated as "nothing meaningful logged yet"
 _EMPTY_FEEDBACK = {None, "", "other", False}
@@ -148,21 +147,97 @@ FEEDBACK_DONE_MAP = {
 }
 
 
-def _classify_visit(
+# ── New visit-model helpers ────────────────────────────────────────────────
+
+
+def _get_latest_active_visit(lead):
+    """
+    Return the latest non-superseded lead.site.visit for this inquiry.
+
+    Superseded visits are the closed leg of a reschedule chain and must be
+    skipped so the API reflects the actual current appointment state.
+    """
+    return lead.sudo().site_visit_ids.filtered(
+        lambda v: v.status_id.code != "superseded"
+    )[:1]
+
+
+def _classify_visit_new(visit, now: datetime) -> str:
+    """
+    Classify a lead.site.visit record using status-type flags.
+
+    Returns one of: "upcoming" | "pending_feedback" | "cancelled" | "completed"
+    """
+    s = visit.status_id
+    if s.is_completed_status:
+        return "completed"
+    if s.is_cancelled_status or s.is_no_show_status:
+        return "cancelled"
+    if visit.scheduled_datetime and visit.scheduled_datetime > now:
+        return "upcoming"
+    return "pending_feedback"
+
+
+def _visit_from_lead_model(lead, visit, now: datetime) -> tuple[str, datetime, dict]:
+    """
+    Build (bucket, sort_key, record_dict) from a leads.new inquiry and its
+    latest lead.site.visit record.
+
+    Reads directly from lead.site.visit to bypass the stale snapshot problem:
+      - feedback_option_id / feedback_note are never written back to leads.new
+      - cancelled / no-show statuses are not synced to leads.new.current_status
+    """
+    bucket = _classify_visit_new(visit, now)
+    prop = visit.property_base_id
+    s = visit.status_id
+
+    current_status_str = "site_visit_done" if s.is_completed_status else "site_visit_scheduled"
+    feedback_code = visit.feedback_option_id.code or None
+    feedback_note = visit.feedback_note or None
+
+    record = {
+        "source": lead.inquiry_type or "primary",
+        "lead_name": lead.name or None,
+        "lead_phone": lead.phone or None,
+        "property_tag": prop.property_tag if prop else None,
+        "property_bhk": prop.bhk if prop else None,
+        "property_location": prop.location if prop else None,
+        "site_visit_datetime": (
+            visit.scheduled_datetime.isoformat() if visit.scheduled_datetime else None
+        ),
+        "site_visit_date": (
+            visit.scheduled_date.isoformat() if visit.scheduled_date else None
+        ),
+        "current_status": current_status_str,
+        "remarks": feedback_note,
+    }
+
+    if bucket == "pending_feedback":
+        record["note"] = "Visit date has passed — awaiting RM feedback"
+    elif bucket == "cancelled":
+        record["feedback_general"] = feedback_code
+        record["note"] = "Visit did not occur due to buyer status"
+    elif bucket == "completed":
+        record["feedback_site_visit_done"] = feedback_code
+
+    return bucket, visit.scheduled_datetime, record
+
+
+# ── Legacy snapshot helpers (lead.property.interest) ──────────────────────
+
+
+def _classify_legacy_visit(
     current_status: str,
     site_visit_date: datetime,
     now: datetime,
     feedback_general: str | None,
 ) -> str:
     """
-    Determine which bucket a visit record belongs to.
+    Classify a legacy lead.property.interest record.
 
-    Returns one of: "upcoming" | "pending_feedback" | "cancelled" | "completed"
-
-    Both new and rescheduled visits appear as "site_visit_scheduled" in the
-    snapshot (written by lead.site.visit._sync_inquiry_snapshot). A reschedule
-    supersedes the original visit and writes a new date, so rescheduled visits
-    land in "upcoming" if the new date is in the future.
+    This path is retained for backward compatibility with interest records that
+    predate the lead.site.visit model.  New visits are handled by
+    _classify_visit_new / _visit_from_lead_model instead.
     """
     if current_status == "site_visit_done":
         return "completed"
@@ -170,150 +245,55 @@ def _classify_visit(
     if current_status == "site_visit_scheduled":
         if site_visit_date > now:
             return "upcoming"
-        # Date is in the past — check feedback_general to decide if the
-        # RM has already logged a reason the visit didn't happen.
         if feedback_general in _EMPTY_FEEDBACK:
             return "pending_feedback"
         return "cancelled"
 
-    # Safety fallback — should not reach here given _VISIT_STATUSES filter
     return "pending_feedback"
 
 
-def _build_base_record(
-    source: str,
-    lead_name,
-    lead_phone,
-    prop,
-    site_visit_date,
-    site_visit_date_only,
-    current_status: str,
-    remarks,
-) -> dict:
-    """Fields present in every bucket."""
-    return {
-        "source": source,
-        "lead_name": lead_name or None,
-        "lead_phone": lead_phone or None,
-        "property_tag": prop.property_tag if prop else None,
-        "property_bhk": prop.bhk if prop else None,
-        "property_location": prop.location if prop else None,
-        "site_visit_datetime": (
-            site_visit_date.isoformat() if site_visit_date else None
-        ),
-        "site_visit_date": (
-            site_visit_date_only.isoformat() if site_visit_date_only else None
-        ),
+def _visit_from_recommended_legacy(interest, now: datetime) -> tuple[str, datetime, dict]:
+    """
+    Build (bucket, sort_key, record_dict) from a legacy lead.property.interest record.
+
+    Retained for backward compatibility with interest records that predate the
+    lead.site.visit model.  New recommended inquiries use leads.new +
+    lead.site.visit and are handled by _visit_from_lead_model instead.
+    """
+    parent = interest.lead_id
+    current_status = interest.current_status
+    site_visit_date = interest.site_visit_date
+    feedback_general = interest.feedback_general
+    feedback_site_visit_done = interest.feedback_site_visit_done
+
+    bucket = _classify_legacy_visit(current_status, site_visit_date, now, feedback_general)
+
+    record = {
+        "source": "recommended",
+        "lead_name": parent.name if parent else None,
+        "lead_phone": parent.phone if parent else None,
+        "property_tag": interest.property_base_id.property_tag if interest.property_base_id else None,
+        "property_bhk": interest.property_base_id.bhk if interest.property_base_id else None,
+        "property_location": interest.property_base_id.location if interest.property_base_id else None,
+        "site_visit_datetime": site_visit_date.isoformat() if site_visit_date else None,
+        "site_visit_date": interest.site_visit_date_only.isoformat() if interest.site_visit_date_only else None,
         "current_status": current_status or None,
-        "remarks": remarks or None,
+        "remarks": interest.remarks or None,
     }
 
-
-def _apply_bucket_fields(
-    record: dict,
-    bucket: str,
-    feedback_general: str | None,
-    feedback_site_visit_done: str | None,
-    remarks,
-) -> dict:
-    """
-    Add bucket-specific fields to the record in-place and return it.
-
-    pending_feedback — note only; no feedback value since none was logged.
-    cancelled        — feedback_general (the reason) + note.
-    completed        — feedback_site_visit_done always; remarks only when "other".
-    upcoming         — no extra fields.
-    """
     if bucket == "pending_feedback":
         record["note"] = "Visit date has passed — awaiting RM feedback"
-
     elif bucket == "cancelled":
         record["feedback_general"] = feedback_general
         record["note"] = "Visit did not occur due to buyer status"
-
     elif bucket == "completed":
         record["feedback_site_visit_done"] = feedback_site_visit_done or None
         if feedback_site_visit_done == "other":
-            record["remarks"] = remarks or None
+            record["remarks"] = interest.remarks or None
         else:
-            # Keep payload clean — remarks only matter when feedback is "other"
             record["remarks"] = None
 
-    return record
-
-
-def _process_visit(
-    source: str,
-    lead_name,
-    lead_phone,
-    prop,
-    site_visit_date,
-    site_visit_date_only,
-    current_status: str,
-    remarks,
-    feedback_general,
-    feedback_site_visit_done,
-    now: datetime,
-) -> tuple[str, datetime, dict]:
-    """
-    Full pipeline for one record: classify → build base → apply bucket fields.
-    Returns (bucket, sort_key, record_dict).
-    """
-    bucket = _classify_visit(current_status, site_visit_date, now, feedback_general)
-
-    record = _build_base_record(
-        source=source,
-        lead_name=lead_name,
-        lead_phone=lead_phone,
-        prop=prop,
-        site_visit_date=site_visit_date,
-        site_visit_date_only=site_visit_date_only,
-        current_status=current_status,
-        remarks=remarks,
-    )
-
-    _apply_bucket_fields(
-        record=record,
-        bucket=bucket,
-        feedback_general=feedback_general,
-        feedback_site_visit_done=feedback_site_visit_done,
-        remarks=remarks,
-    )
-
     return bucket, site_visit_date, record
-
-
-def _visit_from_primary(lead, now: datetime) -> tuple[str, datetime, dict]:
-    return _process_visit(
-        source="primary",
-        lead_name=lead.name,
-        lead_phone=lead.phone,
-        prop=lead.property_base_id,
-        site_visit_date=lead.site_visit_date,
-        site_visit_date_only=lead.site_visit_date_only,
-        current_status=lead.current_status,
-        remarks=lead.remarks,
-        feedback_general=lead.feedback_general,
-        feedback_site_visit_done=lead.feedback_site_visit_done,
-        now=now,
-    )
-
-
-def _visit_from_recommended(interest, now: datetime) -> tuple[str, datetime, dict]:
-    parent = interest.lead_id
-    return _process_visit(
-        source="recommended",
-        lead_name=parent.name if parent else None,
-        lead_phone=parent.phone if parent else None,
-        prop=interest.property_base_id,
-        site_visit_date=interest.site_visit_date,
-        site_visit_date_only=interest.site_visit_date_only,
-        current_status=interest.current_status,
-        remarks=interest.remarks,
-        feedback_general=interest.feedback_general,
-        feedback_site_visit_done=interest.feedback_site_visit_done,
-        now=now,
-    )
 
 
 class SellerSiteVisitsController(http.Controller):
@@ -363,25 +343,23 @@ class SellerSiteVisitsController(http.Controller):
             "completed": [],
         }
 
-        # ── Primary leads ─────────────────────────────────────────────────────
-        primary_leads = get_primary_leads_for_tags(request.env, tags).filtered(
-            lambda lead: (
-                lead.site_visit_date and lead.current_status in _VISIT_STATUSES
-            ),
-        )
-        for lead in primary_leads:
-            bucket, sort_key, record = _visit_from_primary(lead, now)
+        # ── All leads.new for the seller's properties (primary + recommended) ─
+        # get_primary_leads_for_tags returns all leads.new with property_base_id
+        # in the seller's property set — this covers both inquiry_type='primary'
+        # and inquiry_type='recommended' records transparently.
+        for lead in get_primary_leads_for_tags(request.env, tags):
+            visit = _get_latest_active_visit(lead)
+            if not visit:
+                continue
+            bucket, sort_key, record = _visit_from_lead_model(lead, visit, now)
             buckets[bucket].append((sort_key, record))
 
-        # ── Recommended interests ─────────────────────────────────────────────
-        recommended_interests = get_recommended_leads_for_tags(
-            request.env,
-            tags,
-        ).filtered(
-            lambda i: i.site_visit_date and i.current_status in _VISIT_STATUSES,
-        )
-        for interest in recommended_interests:
-            bucket, sort_key, record = _visit_from_recommended(interest, now)
+        # ── Legacy lead.property.interest records ─────────────────────────────
+        # Retained for visits created before the lead.site.visit model existed.
+        for interest in get_recommended_leads_for_tags(request.env, tags).filtered(
+            lambda i: i.site_visit_date and i.current_status in _LEGACY_VISIT_STATUSES,
+        ):
+            bucket, sort_key, record = _visit_from_recommended_legacy(interest, now)
             buckets[bucket].append((sort_key, record))
 
         # ── Sort each bucket ──────────────────────────────────────────────────

--- a/custom_addons/leads/models/lead_import_wizard.py
+++ b/custom_addons/leads/models/lead_import_wizard.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
 import base64
 import csv
-from io import StringIO
 import logging
+from io import StringIO
+
 from odoo import fields, models
 from odoo.exceptions import UserError
 
@@ -10,8 +10,8 @@ _logger = logging.getLogger(__name__)
 
 
 class LeadImportWizard(models.TransientModel):
-    _name = 'lead.import.wizard'
-    _description = 'Lead Scoring Import Wizard'
+    _name = "lead.import.wizard"
+    _description = "Lead Scoring Import Wizard"
 
     csv_file = fields.Binary(string="CSV File", required=True)
     file_name = fields.Char(string="File Name")
@@ -21,118 +21,130 @@ class LeadImportWizard(models.TransientModel):
         if not val:
             return None
         clean_val = val.strip()
-        if clean_val.lower() in ('', 'not filled', 'n/a', 'null'):
+        if clean_val.lower() in ("", "not filled", "n/a", "null"):
             return None
         return clean_val.lower() if to_lower else clean_val
 
     def _find_user_by_name(self, user_name):
         """Finds an Odoo user by their name with fuzzy matching."""
         user_name = self._clean_string(user_name, to_lower=False)
-        _logger.info(f"Searching for user: '{user_name}'")
+        _logger.info("Searching for user: '%s'", user_name)
         if user_name is None:
             _logger.warning("User name is None after cleaning, defaulting to Admin.")
-            return self.env.ref('base.user_admin').id
+            return self.env.ref("base.user_admin").id
 
-        User = self.env['res.users']
-        user_record = User.search([('name', '=ilike', user_name)], limit=1)
+        User = self.env["res.users"]
+        user_record = User.search([("name", "=ilike", user_name)], limit=1)
 
         if not user_record:
-            _logger.warning(f"User '{user_name}' not found, defaulting to Admin.")
-            return self.env.ref('base.user_admin').id
+            _logger.warning("User '%s' not found, defaulting to Admin.", user_name)
+            return self.env.ref("base.user_admin").id
 
         return user_record.id
 
     def _find_property_by_name(self, property_name):
         """Finds a property by its title in property.base and returns its ID."""
-        if not property_name or property_name.strip().lower() in ('', 'not filled', 'n/a'):
+        if not property_name or property_name.strip().lower() in (
+            "",
+            "not filled",
+            "n/a",
+        ):
             return None
-        Property = self.env['property.base']
+        Property = self.env["property.base"]
         # This assumes property names are unique. If not, this will pick the first one it finds.
-        property_record = Property.search([('name', '=ilike', property_name.strip())], limit=1)
+        property_record = Property.search(
+            [("name", "=ilike", property_name.strip())], limit=1
+        )
         return property_record.id if property_record else None
 
     def _clean_lead_status(self, status_str):
         """Maps the status from the CSV to the keys in the Odoo selection field."""
         if not status_str:
-            return 'lead'  # Default value
+            return "lead"  # Default value
 
         status_map = {
-            'busy': 'busy',
-            'lead': 'lead',
-            'ringing': 'ringing',
-            'call back later': 'call_back_later',
-            'site visit scheduled': 'site_visit_scheduled',
-            'option not matching requirements': 'option_not_matching_requirements',
-            'details shared of property': 'details_shared_of_property',
-            'no requiremnets': 'no_requirements',
-            'details shared and interested for site visit': 'details_shared_and_interested_for_site_visit',
-            'switched off': 'switched_off',
-            'requirement closed': 'requirement_closed',
-            'property sold out': 'property_sold_out',
-            'rescheduled': 'rescheduled',
-            'budget not sufficient': 'budget_not_sufficient',
-            'number not in use/wrong number': 'number_not_in_use_wrong_number',
-            'others': 'other',
-
+            "busy": "busy",
+            "lead": "lead",
+            "ringing": "ringing",
+            "call back later": "call_back_later",
+            "site visit scheduled": "site_visit_scheduled",
+            "option not matching requirements": "option_not_matching_requirements",
+            "details shared of property": "details_shared_of_property",
+            "no requiremnets": "no_requirements",
+            "details shared and interested for site visit": "details_shared_and_interested_for_site_visit",
+            "switched off": "switched_off",
+            "requirement closed": "requirement_closed",
+            "property sold out": "property_sold_out",
+            "rescheduled": "rescheduled",
+            "budget not sufficient": "budget_not_sufficient",
+            "number not in use/wrong number": "number_not_in_use_wrong_number",
+            "others": "other",
         }
-        return status_map.get(status_str.strip().lower(), 'lead')  # Default to 'lead' if not found
+        return status_map.get(
+            status_str.strip().lower(), "lead"
+        )  # Default to 'lead' if not found
 
     def action_import_leads(self):
-        """ The main logic for parsing the CSV and creating lead score records. """
+        """The main logic for parsing the CSV and creating lead score records."""
         if not self.csv_file:
             raise UserError("Please upload a CSV file.")
 
-        decoded_file = base64.b64decode(self.csv_file).decode('utf-8')
+        decoded_file = base64.b64decode(self.csv_file).decode("utf-8")
         reader = csv.DictReader(StringIO(decoded_file))
 
-        LeadScore = self.env['lead.score']
+        LeadScore = self.env["lead.score"]
 
         for row in reader:
-            lead_name = row.get('customer_name', '').strip()
+            lead_name = row.get("customer_name", "").strip()
             if not lead_name:
                 continue
 
             # Find related records
-            rm_id = self._find_user_by_name(row.get('assigned_rm'))
+            rm_id = self._find_user_by_name(row.get("assigned_rm"))
             # property_id = self._find_property_by_name(row.get('Project_Name'))
 
             # Clean and map the status
-            lead_state = self._clean_lead_status(row.get('current_status'))
+            lead_state = self._clean_lead_status(row.get("current_status"))
 
             try:
                 vals = {
-                    'name': lead_name,
-                    'standardized_phone': row.get('standardized_phone', '').strip(),
-                    'predicted_score': float(row.get('predicted_score') or 0.0),
-                    'current_status': lead_state,
-
+                    "name": lead_name,
+                    "standardized_phone": row.get("standardized_phone", "").strip(),
+                    "predicted_score": float(row.get("predicted_score") or 0.0),
+                    "current_status": lead_state,
                     # Link to other models
-                    'assigned_rm_id': rm_id,
+                    "assigned_rm_id": rm_id,
                     # 'property_id': property_id,
-                    'project_name': row.get('Project_Name', '').strip(),
-                    'property_type': row.get('Property_Type', '').strip(),
-                    'property_tag': row.get('property_tag', '').strip(),
-                    'property_address': row.get('Property_Address', '').strip(),
-                    'bhk': row.get('BHK', '').strip(),
-                    'price_range': row.get('Price_Range_Lacs_Rs', '').strip(),
-                    'carpet_area': row.get('Carpet_Construction_Area', '').strip(),
-                    'super_built_up_area': row.get('Super_Built_up_Construction_Area', '').strip(),
-                    'property_link': row.get('Property_Link', '').strip(),
-                    'location': row.get('Location', '').strip(),
-                    'property_on_floor': row.get('Property_On_Floor', '').strip(),
-                    'property_facing': row.get('Property_Facing', '').strip(),
-                    'furniture_details': row.get('Furniture_Details', '').strip(),
-                    'age_of_property': row.get('Age_Of_Property', '').strip(),
-                    'parking_details': row.get('Parking_Details', '').strip(),
-                    'offer_price': row.get('Offer_Price', '').strip(),
-                    'bathroom': row.get('Bathroom', '').strip(),
+                    "project_name": row.get("Project_Name", "").strip(),
+                    "property_type": row.get("Property_Type", "").strip(),
+                    "property_tag": row.get("property_tag", "").strip(),
+                    "property_address": row.get("Property_Address", "").strip(),
+                    "bhk": row.get("BHK", "").strip(),
+                    "price_range": row.get("Price_Range_Lacs_Rs", "").strip(),
+                    "carpet_area": row.get("Carpet_Construction_Area", "").strip(),
+                    "super_built_up_area": row.get(
+                        "Super_Built_up_Construction_Area", ""
+                    ).strip(),
+                    "property_link": row.get("Property_Link", "").strip(),
+                    "location": row.get("Location", "").strip(),
+                    "property_on_floor": row.get("Property_On_Floor", "").strip(),
+                    "property_facing": row.get("Property_Facing", "").strip(),
+                    "furniture_details": row.get("Furniture_Details", "").strip(),
+                    "age_of_property": row.get("Age_Of_Property", "").strip(),
+                    "parking_details": row.get("Parking_Details", "").strip(),
+                    "offer_price": row.get("Offer_Price", "").strip(),
+                    "bathroom": row.get("Bathroom", "").strip(),
                     # Fields for RM Interaction
-                    'state': lead_state,
-                    'site_visit_scheduled_date': row.get('site_visit_date') or None,
+                    "state": lead_state,
+                    "site_visit_scheduled_date": row.get("site_visit_date") or None,
                 }
                 LeadScore.create(vals)
             except (ValueError, TypeError) as e:
-                _logger.warning(f"Could not import lead '{lead_name}' due to a data conversion error: {e}")
+                _logger.warning(
+                    "Could not import lead '%s' due to a data conversion error: %s",
+                    lead_name,
+                    e,
+                )
                 continue
 
-        return {'type': 'ir.actions.client', 'tag': 'reload'}
+        return {"type": "ir.actions.client", "tag": "reload"}

--- a/custom_addons/leads/models/lead_site_visit.py
+++ b/custom_addons/leads/models/lead_site_visit.py
@@ -545,10 +545,17 @@ class LeadSiteVisit(models.Model):
         vals = {
             "site_visit_date": self.scheduled_datetime,
         }
-        if self.status_id.is_completed_status:
+
+        s = self.status_id
+        if s.is_completed_status:
             vals["current_status"] = "site_visit_done"
-        elif self.status_id.is_scheduled_status or self.status_id.is_reschedule_status:
+        elif s.is_scheduled_status or s.is_reschedule_status:
             vals["current_status"] = "site_visit_scheduled"
+        # Cancelled / no-show: leave current_status on leads.new unchanged.
+        # There is no matching selection value in leads.new.current_status for
+        # these states; the APIs read from lead.site.visit directly.  The UI
+        # status badge will remain at the last known scheduled/completed value,
+        # which is acceptable — the RM can see the true state on the visit form.
 
         return vals
 

--- a/custom_addons/leads/models/leads_new_inquiry.py
+++ b/custom_addons/leads/models/leads_new_inquiry.py
@@ -78,22 +78,39 @@ class LeadsNewInquiry(models.Model):
     @api.depends("site_visit_ids.scheduled_datetime")
     def _compute_latest_site_visit(self):
         for rec in self:
-            rec.latest_site_visit_id = rec.site_visit_ids[:1]
+            rec.latest_site_visit_id = rec.sudo().site_visit_ids[:1]
 
     @api.depends("site_visit_ids")
     def _compute_site_visit_count(self):
         for rec in self:
-            rec.site_visit_count = len(rec.site_visit_ids)
+            rec.site_visit_count = len(rec.sudo().site_visit_ids)
 
     @api.depends("phone")
     def _compute_all_phone_site_visit_ids(self):
-        site_visit_model = self.env["lead.site.visit"]
+        # Both queries must use sudo() explicitly.
+        #
+        # Using a cross-model domain like ("inquiry_id.phone", "=", phone) on a
+        # sudo()'d lead.site.visit search is NOT sufficient: Odoo applies the
+        # leads.new record rule (user_id = user.id) to the JOIN subquery even
+        # when the outer model is queried with sudo().  This silently excludes
+        # inquiries owned by other RMs, making the overall timeline show only
+        # the current RM's visits.
+        #
+        # Solution: two separate sudo() queries so each model's record rules are
+        # fully bypassed — first resolve all inquiry IDs for the phone, then
+        # fetch all visits for those inquiry IDs.
+        site_visit_model = self.env["lead.site.visit"].sudo()
+        inquiry_model = self.env["leads.new"].sudo()
         for rec in self:
             if not rec.phone:
                 rec.all_phone_site_visit_ids = site_visit_model
                 continue
+            inquiry_ids = inquiry_model.search([("phone", "=", rec.phone)]).ids
+            if not inquiry_ids:
+                rec.all_phone_site_visit_ids = site_visit_model
+                continue
             rec.all_phone_site_visit_ids = site_visit_model.search(
-                [("inquiry_id.phone", "=", rec.phone)],
+                [("inquiry_id", "in", inquiry_ids)],
                 order="scheduled_datetime desc, id desc",
             )
 
@@ -107,12 +124,32 @@ class LeadsNewInquiry(models.Model):
     )
     def _compute_timeline_html(self):
         for rec in self:
+            # All visit data is fetched via rec.sudo() throughout.
+            #
+            # Two reasons:
+            # 1. Record rules: rule_lead_site_visit_rm_own appends
+            #    "assigned_rm_id = user.id" to every lead.site.visit query.
+            #    Visits assigned to other RMs (e.g. a manager scheduled the
+            #    visit, or inquiry.user_id was blank) would be silently hidden.
+            # 2. Model-level ACL: when the Many2many result from
+            #    _compute_all_phone_site_visit_ids (fetched with sudo) is
+            #    accessed on the non-sudo rec, Odoo reconstructs the recordset
+            #    using rec.env (non-sudo).  Subsequent field reads inside
+            #    _build_timeline_html then trigger a model-level access check
+            #    for lead.site.visit on the calling user, raising AccessError
+            #    for users who do not hold the RM group (e.g. test accounts).
+            #
+            # Using rec_sudo for all visit reads ensures the sudo env flows
+            # through to every field access inside _build_timeline_html.
+            # _build_timeline_html is still called on rec (not rec_sudo) so
+            # that self.env.user.has_group() reflects the actual user.
+            rec_sudo = rec.sudo()
             rec.inquiry_timeline_html = rec._build_timeline_html(
-                rec.site_visit_ids,
+                rec_sudo.site_visit_ids,
                 show_inquiry=False,
             )
             rec.overall_timeline_html = rec._build_timeline_html(
-                rec.all_phone_site_visit_ids,
+                rec_sudo.all_phone_site_visit_ids,
                 show_inquiry=True,
             )
 

--- a/custom_addons/leads/tests/__init__.py
+++ b/custom_addons/leads/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    test_cross_rm_access,
     test_buyer_activity_api,
     test_buyer_site_visits_api,
     test_lead_property_interest,

--- a/custom_addons/leads/tests/test_buyer_site_visits_api.py
+++ b/custom_addons/leads/tests/test_buyer_site_visits_api.py
@@ -888,7 +888,7 @@ class TestBuyerSiteVisitsAPI(PortalLeadTestCase):
                  leads.new flat fields automatically.
         ASSERT : leads.new.current_status == "site_visit_scheduled"
                  leads.new.site_visit_date  == the scheduled datetime
-                 The controller's _classify_visit() maps this to "upcoming".
+                 _classify_visit(visit, now) maps the visit to "upcoming".
 
         This verifies that the new model drives the API response correctly without
         any direct writes to leads.new snapshot fields.
@@ -904,7 +904,7 @@ class TestBuyerSiteVisitsAPI(PortalLeadTestCase):
         )
 
         future_dt = self.future_date
-        self.env["lead.site.visit"].create(
+        visit = self.env["lead.site.visit"].create(
             {
                 "inquiry_id": lead.id,
                 "status_id": scheduled_status.id,
@@ -916,13 +916,8 @@ class TestBuyerSiteVisitsAPI(PortalLeadTestCase):
         self.assertEqual(lead.current_status, "site_visit_scheduled")
         self.assertEqual(lead.site_visit_date, future_dt)
 
-        # The controller classifies this as "upcoming".
-        bucket = _classify_visit(
-            current_status=lead.current_status,
-            site_visit_date=lead.site_visit_date,
-            now=self.now,
-            feedback_general=lead.feedback_general,
-        )
+        # The controller classifies this as "upcoming" using the visit record directly.
+        bucket = _classify_visit(visit, self.now)
         self.assertEqual(bucket, "upcoming")
 
     def test_037_new_model_completed_visit_syncs_to_completed_bucket(self):
@@ -962,12 +957,8 @@ class TestBuyerSiteVisitsAPI(PortalLeadTestCase):
         # Snapshot must reflect the completed outcome.
         self.assertEqual(lead.current_status, "site_visit_done")
 
-        bucket = _classify_visit(
-            current_status=lead.current_status,
-            site_visit_date=lead.site_visit_date,
-            now=self.now,
-            feedback_general=lead.feedback_general,
-        )
+        # The controller classifies this as "completed" using the visit record directly.
+        bucket = _classify_visit(visit, self.now)
         self.assertEqual(bucket, "completed")
 
     def test_038_reschedule_via_new_model_appears_in_upcoming_not_rescheduled(self):
@@ -1019,13 +1010,11 @@ class TestBuyerSiteVisitsAPI(PortalLeadTestCase):
             "not 'rescheduled'. The 'rescheduled' bucket is legacy-only.",
         )
 
-        # The API classifies this as "upcoming" because the new visit is in the future.
-        bucket = _classify_visit(
-            current_status=lead.current_status,
-            site_visit_date=lead.site_visit_date,
-            now=self.now,
-            feedback_general=lead.feedback_general,
-        )
+        # The API classifies this as "upcoming" because the new (non-superseded) visit
+        # has a future datetime.  The controller reads from lead.site.visit directly.
+        from odoo.addons.leads.controllers.buyer.site_visits import _get_latest_active_visit
+        active_visit = _get_latest_active_visit(lead)
+        bucket = _classify_visit(active_visit, self.now)
         self.assertEqual(
             bucket,
             "upcoming",

--- a/custom_addons/leads/tests/test_cross_rm_access.py
+++ b/custom_addons/leads/tests/test_cross_rm_access.py
@@ -1,0 +1,388 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+from odoo.tests.common import new_test_user
+
+from .test_portal_common import PortalLeadTestCase
+
+
+# ---------------------------------------------------------------------------
+# Module : leads
+# Tests  : Cross-RM access correctness
+# Purpose: Regression tests for three bugs fixed in April 2026:
+#
+#   BUG-1  Recommended inquiry duplicate check was blind to inquiries owned
+#          by other RMs — leads.new record rule (user_id = user.id) silently
+#          filtered them out, allowing a duplicate recommended inquiry on the
+#          same buyer+property to be created by a second RM.
+#
+#   BUG-2  Inquiry Timeline (site_visit_ids) was empty for RM users when the
+#          visit's assigned_rm_id differed from the viewing RM — caused by the
+#          lead.site.visit record rule (assigned_rm_id = user.id) hiding the
+#          visit in the One2many read.
+#
+#   BUG-3  Overall Lead Timeline (_compute_all_phone_site_visit_ids) returned
+#          only the current RM's own visits — the cross-model domain
+#          ("inquiry_id.phone", …) applied the leads.new record rule to the
+#          JOIN subquery even when the outer search used sudo(), hiding
+#          inquiries owned by other RMs and their associated visits.
+#
+#   BUG-4  AccessError on visit field access: when the Many2many recordset from
+#          all_phone_site_visit_ids (fetched with sudo) was later accessed via
+#          the non-sudo rec, Odoo re-ran model-level ACL checks using rec.env,
+#          raising "doesn't have 'read' access to lead.site.visit" for users
+#          who aren't in the RM group at the point of record read.
+#
+# Owner  : Cleardeals Tech
+# ---------------------------------------------------------------------------
+
+
+@tagged("post_install", "-at_install")
+class TestCrossRMRecommendedDuplicate(PortalLeadTestCase):
+    """BUG-1 — Duplicate recommended inquiry check must be cross-RM."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.second_property = cls.env["property.base"].create(
+            {
+                "property_tag": f"TEST-PROP-B-{cls.suffix}",
+                "name": f"Test Property B {cls.suffix}",
+                "prop_id": f"TPB{cls.suffix}",
+                "bedroom_count": 2,
+                "location": "Test Location B",
+                "city": "Test City B",
+                "rm_user_id": cls.test_rm_a.id,
+                "is_active": True,
+            }
+        )
+
+    def test_01_recommended_duplicate_blocked_across_rms(self):
+        """
+        ARRANGE: RM-A creates a primary inquiry with phone P on property X.
+                 RM-A creates a recommended inquiry for property Y on that
+                 primary inquiry.
+        ACT    : RM-B opens the same primary inquiry and tries to create
+                 another recommended inquiry for property Y via the wizard.
+        ASSERT : ValidationError is raised — the existing recommended
+                 inquiry (owned by RM-A) must be found despite the record
+                 rule filtering.
+        """
+        primary = self.env["leads.new"].with_context(
+            automated_lead_creation=True
+        ).create(
+            {
+                "name": "Cross RM Duplicate Test",
+                "phone": f"99001{self.suffix[-5:]}",
+                "source_id": self.source_magicbricks.id,
+                "property_base_id": self.test_property.id,
+                "user_id": self.test_rm_a.id,
+                "state": "assigned",
+                "inquiry_type": "primary",
+            }
+        )
+
+        # RM-A creates the first recommended inquiry for second_property.
+        wizard_a = (
+            self.env["lead.recommend.property.wizard"]
+            .with_user(self.test_rm_a)
+            .with_context(default_inquiry_id=primary.id)
+            .create(
+                {
+                    "inquiry_id": primary.id,
+                    "property_base_id": self.second_property.id,
+                    "assigned_rm_id": self.test_rm_a.id,
+                }
+            )
+        )
+        wizard_a.action_create_recommended_inquiry()
+
+        # RM-B now attempts to create a recommended inquiry for the same
+        # property on the same primary inquiry.
+        wizard_b = (
+            self.env["lead.recommend.property.wizard"]
+            .with_user(self.test_rm_b)
+            .with_context(default_inquiry_id=primary.id)
+            .create(
+                {
+                    "inquiry_id": primary.id,
+                    "property_base_id": self.second_property.id,
+                    "assigned_rm_id": self.test_rm_b.id,
+                }
+            )
+        )
+
+        with self.assertRaises(
+            ValidationError,
+            msg="Duplicate recommended inquiry across RMs must be blocked.",
+        ):
+            wizard_b.action_create_recommended_inquiry()
+
+    def test_02_recommended_allowed_for_different_property(self):
+        """
+        ARRANGE: RM-A has a recommended inquiry for property Y.
+        ACT    : RM-B creates a recommended inquiry for property Z (different).
+        ASSERT : No duplicate error — different property is allowed.
+        """
+        primary = self.env["leads.new"].with_context(
+            automated_lead_creation=True
+        ).create(
+            {
+                "name": "Cross RM Diff Property Test",
+                "phone": f"99002{self.suffix[-5:]}",
+                "source_id": self.source_magicbricks.id,
+                "property_base_id": self.test_property.id,
+                "user_id": self.test_rm_a.id,
+                "state": "assigned",
+                "inquiry_type": "primary",
+            }
+        )
+
+        third_property = self.env["property.base"].create(
+            {
+                "property_tag": f"TEST-PROP-C-{self.suffix}",
+                "name": f"Test Property C {self.suffix}",
+                "prop_id": f"TPC{self.suffix}",
+                "bedroom_count": 3,
+                "location": "Test Location C",
+                "city": "Test City C",
+                "rm_user_id": self.test_rm_b.id,
+                "is_active": True,
+            }
+        )
+
+        wizard_a = (
+            self.env["lead.recommend.property.wizard"]
+            .with_user(self.test_rm_a)
+            .with_context(default_inquiry_id=primary.id)
+            .create(
+                {
+                    "inquiry_id": primary.id,
+                    "property_base_id": self.second_property.id,
+                    "assigned_rm_id": self.test_rm_a.id,
+                }
+            )
+        )
+        wizard_a.action_create_recommended_inquiry()
+
+        # RM-B creates for a DIFFERENT property — should succeed.
+        wizard_b = (
+            self.env["lead.recommend.property.wizard"]
+            .with_user(self.test_rm_b)
+            .with_context(default_inquiry_id=primary.id)
+            .create(
+                {
+                    "inquiry_id": primary.id,
+                    "property_base_id": third_property.id,
+                    "assigned_rm_id": self.test_rm_b.id,
+                }
+            )
+        )
+        action = wizard_b.action_create_recommended_inquiry()
+        new_rec = self.env["leads.new"].browse(action["res_id"])
+        self.assertTrue(new_rec.exists())
+        self.assertEqual(new_rec.inquiry_type, "recommended")
+
+
+@tagged("post_install", "-at_install")
+class TestCrossRMVisitTimeline(PortalLeadTestCase):
+    """BUG-2, BUG-3, BUG-4 — Inquiry and Overall timelines must work cross-RM."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.scheduled_status = cls.env["lead.site.visit.status"].search(
+            [("code", "=", "scheduled")], limit=1
+        )
+        if not cls.scheduled_status:
+            raise Exception("'scheduled' site visit status seed data is missing.")
+
+        cls.second_property = cls.env["property.base"].create(
+            {
+                "property_tag": f"TEST-PROP-TL-{cls.suffix}",
+                "name": f"Timeline Test Property {cls.suffix}",
+                "prop_id": f"TPTL{cls.suffix}",
+                "bedroom_count": 2,
+                "location": "Timeline Location",
+                "city": "Timeline City",
+                "rm_user_id": cls.test_rm_b.id,
+                "is_active": True,
+            }
+        )
+
+    def _make_primary(self, phone, rm_user, property_rec=None):
+        return self.env["leads.new"].with_context(
+            automated_lead_creation=True
+        ).create(
+            {
+                "name": f"TL Lead {phone}",
+                "phone": phone,
+                "source_id": self.source_magicbricks.id,
+                "property_base_id": (property_rec or self.test_property).id,
+                "user_id": rm_user.id,
+                "state": "assigned",
+                "inquiry_type": "primary",
+            }
+        )
+
+    def _make_visit(self, inquiry, rm_user=None, dt="2026-05-01 10:00:00"):
+        return self.env["lead.site.visit"].sudo().create(
+            {
+                "inquiry_id": inquiry.id,
+                "property_base_id": inquiry.property_base_id.id,
+                "assigned_rm_id": (rm_user or inquiry.user_id).id,
+                "scheduled_datetime": dt,
+                "status_id": self.scheduled_status.id,
+            }
+        )
+
+    def test_03_inquiry_timeline_visible_to_assigned_rm(self):
+        """
+        BUG-2 — RM can see their own inquiry's visits in the Inquiry Timeline
+        even though the visit's assigned_rm_id equals their own user.id (the
+        record rule should not block this).
+        """
+        phone = f"99003{self.suffix[-5:]}"
+        inquiry = self._make_primary(phone, self.test_rm_a)
+        self._make_visit(inquiry, self.test_rm_a)
+
+        # Read via the RM's env — the timeline must not be empty.
+        inquiry_as_rm = inquiry.with_user(self.test_rm_a)
+        timeline = inquiry_as_rm.sudo().site_visit_ids
+        self.assertEqual(len(timeline), 1, "RM must see their own inquiry's visit.")
+
+    def test_04_inquiry_timeline_visible_when_visit_assigned_to_other_rm(self):
+        """
+        BUG-2 — If a visit on RM-A's inquiry is assigned to RM-B (e.g. a
+        manager books it), RM-A must still see it in the Inquiry Timeline.
+        The visit belongs to the inquiry via inquiry_id, but assigned_rm_id =
+        RM-B; the record rule must not hide it from RM-A's perspective.
+        """
+        phone = f"99004{self.suffix[-5:]}"
+        inquiry = self._make_primary(phone, self.test_rm_a)
+        # Visit assigned to RM-B on RM-A's inquiry.
+        self._make_visit(inquiry, self.test_rm_b)
+
+        # The sudo() read bypasses the rule — visit must be there.
+        inquiry_sudo = inquiry.sudo()
+        self.assertEqual(
+            len(inquiry_sudo.site_visit_ids),
+            1,
+            "Visit on inquiry must be visible regardless of assigned_rm_id.",
+        )
+
+    def test_05_overall_timeline_shows_visits_from_other_rms(self):
+        """
+        BUG-3 — Overall Lead Timeline must include visits from ALL inquiries
+        for the same phone number, regardless of which RM owns each inquiry.
+
+        ARRANGE: phone P has two inquiries — one owned by RM-A (property X),
+                 one owned by RM-B (property Y).  Each has one scheduled visit.
+        ACT    : read all_phone_site_visit_ids from RM-A's inquiry (as RM-A).
+        ASSERT : both visits appear — not just RM-A's own.
+        """
+        phone = f"99005{self.suffix[-5:]}"
+        inquiry_a = self._make_primary(phone, self.test_rm_a, self.test_property)
+        inquiry_b = self._make_primary(phone, self.test_rm_b, self.second_property)
+
+        self._make_visit(inquiry_a, self.test_rm_a, "2026-05-01 10:00:00")
+        self._make_visit(inquiry_b, self.test_rm_b, "2026-05-02 10:00:00")
+
+        # Read all_phone_site_visit_ids as computed on RM-A's inquiry.
+        # The field is non-stored (compute), so we invalidate to force recompute.
+        inquiry_a.invalidate_recordset(["all_phone_site_visit_ids"])
+        all_visits = inquiry_a.sudo().all_phone_site_visit_ids
+
+        self.assertEqual(
+            len(all_visits),
+            2,
+            "Overall timeline must show visits from both RM-A and RM-B inquiries.",
+        )
+
+    def test_06_overall_timeline_empty_when_no_phone(self):
+        """
+        Edge case: overall timeline must return empty (not crash) when the
+        inquiry has no phone number.
+        """
+        inquiry = self.env["leads.new"].with_context(
+            automated_lead_creation=True
+        ).create(
+            {
+                "name": "No Phone Lead",
+                "source_id": self.source_magicbricks.id,
+                "property_base_id": self.test_property.id,
+                "user_id": self.test_rm_a.id,
+                "state": "assigned",
+                "inquiry_type": "primary",
+            }
+        )
+        self.assertFalse(inquiry.phone)
+        inquiry.invalidate_recordset(["all_phone_site_visit_ids"])
+        self.assertFalse(
+            inquiry.sudo().all_phone_site_visit_ids,
+            "Overall timeline must be empty when inquiry has no phone.",
+        )
+
+    def test_07_inquiry_timeline_html_no_access_error_for_rm(self):
+        """
+        BUG-4 — Computing inquiry_timeline_html and overall_timeline_html for
+        an RM user must not raise AccessError for lead.site.visit.
+
+        The bug was that Many2many records fetched with sudo() were later
+        accessed via the non-sudo rec env, triggering model-level ACL checks.
+        """
+        phone = f"99007{self.suffix[-5:]}"
+        inquiry = self._make_primary(phone, self.test_rm_a)
+        self._make_visit(inquiry, self.test_rm_a)
+
+        # Force recompute via the RM's user environment.
+        inquiry_as_rm = inquiry.with_user(self.test_rm_a)
+        inquiry_as_rm.invalidate_recordset(
+            ["inquiry_timeline_html", "overall_timeline_html"]
+        )
+
+        # These must not raise AccessError.
+        try:
+            html = inquiry_as_rm.inquiry_timeline_html
+            overall = inquiry_as_rm.overall_timeline_html
+        except Exception as exc:
+            self.fail(
+                f"Timeline HTML compute raised an exception for RM user: {exc}"
+            )
+
+        self.assertTrue(html, "Inquiry timeline HTML must be non-empty.")
+
+    def test_08_overall_timeline_html_shows_other_rm_visits(self):
+        """
+        BUG-3 + BUG-4 combined — Overall timeline HTML for RM-A must include
+        visit rows that belong to RM-B's inquiry on the same phone number.
+        """
+        phone = f"99008{self.suffix[-5:]}"
+        inquiry_a = self._make_primary(phone, self.test_rm_a, self.test_property)
+        inquiry_b = self._make_primary(phone, self.test_rm_b, self.second_property)
+
+        self._make_visit(inquiry_a, self.test_rm_a, "2026-05-01 10:00:00")
+        self._make_visit(inquiry_b, self.test_rm_b, "2026-05-02 10:00:00")
+
+        inquiry_a_as_rm = inquiry_a.with_user(self.test_rm_a)
+        inquiry_a_as_rm.invalidate_recordset(["overall_timeline_html"])
+
+        try:
+            overall_html = inquiry_a_as_rm.overall_timeline_html
+        except Exception as exc:
+            self.fail(
+                f"overall_timeline_html raised an exception for RM user: {exc}"
+            )
+
+        # Both property names must appear in the rendered HTML.
+        self.assertIn(
+            self.test_property.name,
+            overall_html,
+            "Overall timeline must mention RM-A's property.",
+        )
+        self.assertIn(
+            self.second_property.name,
+            overall_html,
+            "Overall timeline must mention RM-B's property (cross-RM visit).",
+        )

--- a/custom_addons/leads/tests/test_seller_site_visits_api.py
+++ b/custom_addons/leads/tests/test_seller_site_visits_api.py
@@ -969,12 +969,12 @@ class TestSellerSiteVisitsAPI(PortalLeadTestCase):
                  leads.new flat fields automatically.
         ASSERT : leads.new.current_status == "site_visit_scheduled"
                  leads.new.site_visit_date  == the scheduled datetime
-                 The controller's _classify_visit() maps this to "upcoming".
+                 _classify_visit_new(visit, now) maps the visit to "upcoming".
 
         This verifies that the new model drives the seller API response correctly
         without any direct writes to leads.new snapshot fields.
         """
-        from odoo.addons.leads.controllers.seller.site_visits import _classify_visit
+        from odoo.addons.leads.controllers.seller.site_visits import _classify_visit_new
 
         now = datetime.now()
         lead = self.create_portal_lead(
@@ -986,7 +986,7 @@ class TestSellerSiteVisitsAPI(PortalLeadTestCase):
         )
         future_dt = now + timedelta(days=7)
 
-        self.env["lead.site.visit"].create(
+        visit = self.env["lead.site.visit"].create(
             {
                 "inquiry_id": lead.id,
                 "status_id": scheduled_status.id,
@@ -998,13 +998,8 @@ class TestSellerSiteVisitsAPI(PortalLeadTestCase):
         self.assertEqual(lead.current_status, "site_visit_scheduled")
         self.assertEqual(lead.site_visit_date, future_dt)
 
-        # The controller classifies this as "upcoming".
-        bucket = _classify_visit(
-            current_status=lead.current_status,
-            site_visit_date=lead.site_visit_date,
-            now=now,
-            feedback_general=lead.feedback_general,
-        )
+        # The controller classifies this as "upcoming" using the visit record directly.
+        bucket = _classify_visit_new(visit, now)
         self.assertEqual(bucket, "upcoming")
 
     def test_34_new_model_completed_visit_syncs_to_completed_bucket(self):
@@ -1013,12 +1008,12 @@ class TestSellerSiteVisitsAPI(PortalLeadTestCase):
         ACT    : Mark the visit 'completed'. Snapshot updates current_status
                  to "site_visit_done".
         ASSERT : leads.new.current_status == "site_visit_done"
-                 _classify_visit() maps this to "completed".
+                 _classify_visit_new(visit, now) maps it to "completed".
 
         Normal post-visit flow: RM marks visit done, snapshot flips the inquiry
         to site_visit_done, seller API shows it in the "completed" bucket.
         """
-        from odoo.addons.leads.controllers.seller.site_visits import _classify_visit
+        from odoo.addons.leads.controllers.seller.site_visits import _classify_visit_new
 
         now = datetime.now()
         lead = self.create_portal_lead(
@@ -1043,12 +1038,7 @@ class TestSellerSiteVisitsAPI(PortalLeadTestCase):
 
         self.assertEqual(lead.current_status, "site_visit_done")
 
-        bucket = _classify_visit(
-            current_status=lead.current_status,
-            site_visit_date=lead.site_visit_date,
-            now=now,
-            feedback_general=lead.feedback_general,
-        )
+        bucket = _classify_visit_new(visit, now)
         self.assertEqual(bucket, "completed")
 
     def test_35_reschedule_via_new_model_appears_in_upcoming_not_rescheduled(self):
@@ -1058,13 +1048,16 @@ class TestSellerSiteVisitsAPI(PortalLeadTestCase):
                  The model supersedes the original and creates a new 'scheduled' visit.
                  The snapshot receives current_status="site_visit_scheduled".
         ASSERT : leads.new.current_status == "site_visit_scheduled" (NOT "rescheduled")
-                 _classify_visit() returns "upcoming" for the new future date.
+                 _classify_visit_new(active_visit, now) returns "upcoming".
 
         Critical contract: the "rescheduled" bucket is NEVER populated by the new
         visit model. Reschedules always appear in "upcoming". The "rescheduled"
         bucket is legacy-only (pre-visit-model direct writes).
         """
-        from odoo.addons.leads.controllers.seller.site_visits import _classify_visit
+        from odoo.addons.leads.controllers.seller.site_visits import (
+            _classify_visit_new,
+            _get_latest_active_visit,
+        )
 
         now = datetime.now()
         lead = self.create_portal_lead(
@@ -1098,12 +1091,9 @@ class TestSellerSiteVisitsAPI(PortalLeadTestCase):
             "not 'rescheduled'. The 'rescheduled' bucket is legacy-only.",
         )
 
-        bucket = _classify_visit(
-            current_status=lead.current_status,
-            site_visit_date=lead.site_visit_date,
-            now=now,
-            feedback_general=lead.feedback_general,
-        )
+        # The controller gets the latest non-superseded visit and classifies it.
+        active_visit = _get_latest_active_visit(lead)
+        bucket = _classify_visit_new(active_visit, now)
         self.assertEqual(
             bucket,
             "upcoming",

--- a/custom_addons/leads/wizard/lead_recommend_property_wizard.py
+++ b/custom_addons/leads/wizard/lead_recommend_property_wizard.py
@@ -77,7 +77,7 @@ class LeadRecommendPropertyWizard(models.TransientModel):
                 "Source is required on the original inquiry.",
             )
 
-        duplicate = self.env["leads.new"].search(
+        duplicate = self.env["leads.new"].sudo().search(
             [
                 ("phone", "=", inquiry.phone),
                 ("property_base_id", "=", self.property_base_id.id),


### PR DESCRIPTION
This pull request makes significant improvements to the site visit API endpoints for both buyers and sellers by migrating all logic to read directly from the `lead.site.visit` model, rather than relying on potentially stale snapshot fields on `leads.new`. The changes clarify feedback field sourcing, enhance bucket classification logic, and unify the data model for both primary and recommended inquiries. This results in more accurate, robust, and maintainable API responses.

**API Documentation Improvements:**

* Updated the documentation to clarify that all feedback and status fields for site visits are now sourced directly from the `lead.site.visit` model, ensuring accuracy for feedback, cancellation, and no-show statuses. [[1]](diffhunk://#diff-dfd9956b59dea3d41eb075755b84205a1274c6bca05f935a66c2afd0938680beL171-R180) [[2]](diffhunk://#diff-dfd9956b59dea3d41eb075755b84205a1274c6bca05f935a66c2afd0938680beR189-R190)
* Revised the bucket classification logic to use status-type flags (`is_scheduled`, `is_rescheduled`, `is_cancelled`, `is_no_show`, `is_completed`) from `lead.site.visit.status`, rather than string comparisons on `current_status`. This change makes the classification more robust and correctly handles edge cases like no-shows and reschedules.
* Expanded the documentation tables to show the precise model field sources for each response field, improving transparency and maintainability. [[1]](diffhunk://#diff-dfd9956b59dea3d41eb075755b84205a1274c6bca05f935a66c2afd0938680beL209-R257) [[2]](diffhunk://#diff-dfd9956b59dea3d41eb075755b84205a1274c6bca05f935a66c2afd0938680beL572-R603)

**Backend Logic Refactoring:**

* Rewrote the buyer site visits controller logic to:
  - Always fetch the latest non-superseded visit from `lead.site.visit` for each inquiry.
  - Classify and build response records using only the visit model, eliminating reliance on legacy snapshot fields and reducing code duplication.
  - Remove legacy handling for recommended property visits that predate the visit model. [[1]](diffhunk://#diff-59e24c751c5a59ff0f01eb67329cb90fc0f4ace71e14d36215ff2da216dc7e55L108-R195) [[2]](diffhunk://#diff-59e24c751c5a59ff0f01eb67329cb90fc0f4ace71e14d36215ff2da216dc7e55L327-R242)
* Updated the seller site visits controller to clarify which statuses are used for legacy snapshot paths and to align with the new model-based approach.

These changes ensure that the API always returns up-to-date, accurate site visit data, and that future changes to visit statuses or feedback options will not require additional API refactoring.Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
