### PR TITLE
Enhance site-visit feedback and recommended inquiries handling

### DIFF
--- a/custom_addons/leads/controllers/API_DOCUMENTATION.md
+++ b/custom_addons/leads/controllers/API_DOCUMENTATION.md
@@ -335,16 +335,20 @@ Returns a full activity overview for a buyer: summary counts and a list of all p
 
 | Field                    | Type              | Description                                              |
 |--------------------------|-------------------|----------------------------------------------------------|
+| `lead_id`                | `integer`         | Odoo ID of the inquiry record                            |
 | `lead_name`              | `string \| null`  | Buyer name on this inquiry                               |
 | `source`                 | `string \| null`  | Source the inquiry came from                             |
 | `inquiry_datetime`       | `string \| null`  | ISO 8601 datetime the inquiry was created                |
 | `current_status`         | `string \| null`  | Current lead status                                      |
 | `first_contacted_on`     | `string \| null`  | ISO 8601 datetime of first RM contact                    |
+| `remarks`                | `string \| null`  | RM free-text note from the latest site visit             |
+| `feedback_general`       | `string \| null`  | Feedback option code when visit is cancelled/no-show     |
+| `feedback_site_visit_done` | `string \| null` | Feedback option code when visit is completed            |
 | `has_property`           | `boolean`         | Whether a property is linked to this lead                |
 | `property`               | `object \| null`  | Property details (see below)                             |
 | `site_visit_datetime`    | `string \| null`  | ISO 8601 datetime of the scheduled/completed site visit  |
 | `site_visit_date`        | `string \| null`  | Date-only string                                         |
-| `recommended_properties` | `array`           | List of recommended property interest records            |
+| `recommended_properties` | `array`           | Recommended child inquiries for this lead                |
 
 **`property` object (when `has_property: true`):**
 
@@ -358,15 +362,18 @@ Returns a full activity overview for a buyer: summary counts and a list of all p
 
 **Each item in `recommended_properties`:**
 
-| Field                 | Type             | Description                              |
-|-----------------------|------------------|------------------------------------------|
-| `property_tag`        | `string \| null` | Tag of the recommended property          |
-| `bhk`                 | `string \| null` | Size                                     |
-| `location`            | `string \| null` | Locality                                 |
-| `city`                | `string \| null` | City                                     |
-| `current_status`      | `string \| null` | Status of the interest record            |
-| `site_visit_datetime` | `string \| null` | ISO 8601 datetime                        |
-| `site_visit_date`     | `string \| null` | Date-only string                         |
+| Field                 | Type             | Description                                              |
+|-----------------------|------------------|----------------------------------------------------------|
+| `interest_id`         | `integer`        | Odoo ID of the recommended inquiry record                |
+| `property_tag`        | `string \| null` | Tag of the recommended property                          |
+| `bhk`                 | `string \| null` | Size                                                     |
+| `location`            | `string \| null` | Locality                                                 |
+| `city`                | `string \| null` | City                                                     |
+| `property_link`       | `string \| null` | URL to the property listing                              |
+| `current_status`      | `string \| null` | Status snapshot of the recommended inquiry               |
+| `site_visit_datetime` | `string \| null` | ISO 8601 datetime                                        |
+| `site_visit_date`     | `string \| null` | Date-only string                                         |
+| `remarks`             | `string \| null` | RM free-text note from the latest site visit             |
 
 #### Success example
 
@@ -383,11 +390,15 @@ Returns a full activity overview for a buyer: summary counts and a list of all p
     },
     "primary_inquiries": [
       {
+        "lead_id": 12,
         "lead_name": "Priya Mehta",
         "source": "99acres",
         "inquiry_datetime": "2025-06-15T09:30:00",
         "current_status": "site_visit_scheduled",
         "first_contacted_on": "2025-06-15T11:00:00",
+        "remarks": null,
+        "feedback_general": null,
+        "feedback_site_visit_done": null,
         "has_property": true,
         "property": {
           "property_tag": "CLR-3BHK-BOD-007",
@@ -400,13 +411,16 @@ Returns a full activity overview for a buyer: summary counts and a list of all p
         "site_visit_date": "2025-07-22",
         "recommended_properties": [
           {
+            "interest_id": 55,
             "property_tag": "CLR-3BHK-PRH-012",
             "bhk": "3BHK",
             "location": "Prahladnagar",
             "city": "Ahmedabad",
+            "property_link": "https://example.com/listing/012",
             "current_status": "details_shared_of_property",
             "site_visit_datetime": null,
-            "site_visit_date": null
+            "site_visit_date": null,
+            "remarks": null
           }
         ]
       }
@@ -647,20 +661,21 @@ Paginated, chronologically-sorted list of every lead record (primary and recomme
 | Field                     | Type             | Description                                                    |
 |---------------------------|------------------|----------------------------------------------------------------|
 | `type`                    | `string`         | `"primary"` or `"recommended"`                                 |
+| `lead_id`                 | `integer`        | Odoo ID of the inquiry record                                  |
 | `lead_name`               | `string \| null` | Buyer name                                                     |
 | `lead_phone`              | `string \| null` | Buyer phone                                                    |
 | `source`                  | `string \| null` | Source of origin (from parent lead for recommended)            |
 | `property_tag`            | `string \| null` | Property tag                                                   |
 | `property_bhk`            | `string \| null` | Property size                                                  |
 | `property_location`       | `string \| null` | Locality                                                       |
-| `inquiry_datetime`        | `string \| null` | ISO 8601 — `create_date` of the lead or interest record        |
+| `inquiry_datetime`        | `string \| null` | ISO 8601 — `create_date` of the inquiry record                 |
 | `current_status`          | `string \| null` | Current status                                                 |
 | `first_contacted_on`      | `string \| null` | ISO 8601 — first RM contact datetime (from parent lead for recommended) |
 | `site_visit_datetime`     | `string \| null` | ISO 8601 datetime                                              |
 | `site_visit_date`         | `string \| null` | Date-only string                                               |
-| `remarks`                 | `string \| null` | RM notes                                                       |
-| `feedback_general`        | `string \| null` | General feedback                                               |
-| `feedback_site_visit_done`| `string \| null` | Post-visit feedback                                            |
+| `remarks`                 | `string \| null` | RM free-text note from the latest site visit                   |
+| `feedback_general`        | `string \| null` | Feedback option code when visit is cancelled/no-show           |
+| `feedback_site_visit_done`| `string \| null` | Feedback option code when visit is completed                   |
 
 > Results are sorted by `inquiry_datetime` descending (most recent first). Records with `null` datetime sort last.
 
@@ -676,6 +691,7 @@ Paginated, chronologically-sorted list of every lead record (primary and recomme
     "items": [
       {
         "type": "primary",
+        "lead_id": 42,
         "lead_name": "Kiran Patel",
         "lead_phone": "9000000001",
         "source": "Housing.com",

--- a/custom_addons/leads/controllers/buyer/activity.py
+++ b/custom_addons/leads/controllers/buyer/activity.py
@@ -80,6 +80,13 @@ from ..shared.response_utils import error_response, success_response
 _logger = logging.getLogger(__name__)
 
 
+def _get_latest_active_visit(lead):
+    """Return the most recent non-superseded site visit for a leads.new record, or False."""
+    return lead.sudo().site_visit_ids.filtered(
+        lambda v: v.status_id.code != "superseded"
+    )[:1]
+
+
 def _serialize_property(prop) -> dict | None:
     if not prop:
         return None
@@ -92,31 +99,42 @@ def _serialize_property(prop) -> dict | None:
     }
 
 
-def _serialize_recommended_interest(interest) -> dict:
-    prop = interest.property_base_id
+def _serialize_recommended_lead(inquiry) -> dict:
+    prop = inquiry.sudo().property_base_id or None
+    visit = _get_latest_active_visit(inquiry)
     return {
+        "interest_id": inquiry.id,
         "property_tag": prop.property_tag if prop else None,
         "bhk": prop.bhk if prop else None,
         "location": prop.location if prop else None,
         "city": prop.city if prop else None,
-        "current_status": interest.current_status or None,
+        "property_link": prop.property_link if prop else None,
+        "current_status": inquiry.current_status or None,
         "site_visit_datetime": (
-            interest.site_visit_date.isoformat() if interest.site_visit_date else None
+            inquiry.site_visit_date.isoformat() if inquiry.site_visit_date else None
         ),
         "site_visit_date": (
-            interest.site_visit_date_only.isoformat()
-            if interest.site_visit_date_only
+            inquiry.site_visit_date_only.isoformat()
+            if inquiry.site_visit_date_only
             else None
         ),
+        "remarks": (visit.feedback_note or None) if visit else None,
     }
 
 
 def _serialize_primary_lead(lead) -> dict:
     prop = lead.property_base_id or None
+    visit = _get_latest_active_visit(lead)
 
-    recommended = [_serialize_recommended_interest(i) for i in lead.interest_ids]
+    s = visit.status_id if visit else None
+    feedback_code = (visit.feedback_option_id.code or None) if visit else None
+    feedback_general = feedback_code if (s and (s.is_cancelled_status or s.is_no_show_status)) else None
+    feedback_done = feedback_code if (s and s.is_completed_status) else None
+
+    recommended = [_serialize_recommended_lead(c) for c in lead.sudo().child_inquiry_ids]
 
     return {
+        "lead_id": lead.id,
         "lead_name": lead.name or None,
         "source": lead.source_id.name or None,
         "inquiry_datetime": (
@@ -128,6 +146,9 @@ def _serialize_primary_lead(lead) -> dict:
             if lead.first_contact_datetime
             else None
         ),
+        "remarks": (visit.feedback_note or None) if visit else None,
+        "feedback_general": feedback_general,
+        "feedback_site_visit_done": feedback_done,
         "has_property": bool(prop),
         "property": _serialize_property(prop),
         "site_visit_datetime": (
@@ -163,7 +184,10 @@ class BuyerActivityController(http.Controller):
         leads = (
             request.env["leads.new"]
             .sudo()
-            .search([("phone", "=", phone)], order="create_date desc")
+            .search(
+                [("phone", "=", phone), ("inquiry_type", "=", "primary")],
+                order="create_date desc",
+            )
         )
 
         if not leads:
@@ -184,20 +208,26 @@ class BuyerActivityController(http.Controller):
             # Count property touchpoints
             if lead.property_base_id:
                 total_properties += 1
-            total_properties += len(lead.interest_ids)
+            total_properties += len(lead.sudo().child_inquiry_ids)
 
-            # Count visit milestones across primary lead
-            if lead.current_status == "site_visit_scheduled":
-                site_visits_scheduled += 1
-            if lead.current_status == "site_visit_done":
-                site_visits_done += 1
-
-            # Count visit milestones across recommended interests
-            for interest in lead.interest_ids:
-                if interest.current_status == "site_visit_scheduled":
+            # Count visit milestones for the primary lead using live visit status flags
+            primary_visit = _get_latest_active_visit(lead)
+            if primary_visit:
+                ps = primary_visit.status_id
+                if ps.is_scheduled_status or ps.is_reschedule_status:
                     site_visits_scheduled += 1
-                if interest.current_status == "site_visit_done":
+                elif ps.is_completed_status:
                     site_visits_done += 1
+
+            # Count visit milestones for each recommended child inquiry
+            for child in lead.sudo().child_inquiry_ids:
+                child_visit = _get_latest_active_visit(child)
+                if child_visit:
+                    cs = child_visit.status_id
+                    if cs.is_scheduled_status or cs.is_reschedule_status:
+                        site_visits_scheduled += 1
+                    elif cs.is_completed_status:
+                        site_visits_done += 1
 
         data = {
             "buyer_phone": phone,

--- a/custom_addons/leads/controllers/seller/activity.py
+++ b/custom_addons/leads/controllers/seller/activity.py
@@ -51,13 +51,26 @@ from ..shared.response_utils import error_response, paginate, success_response
 _logger = logging.getLogger(__name__)
 
 
+def _get_latest_active_visit(lead):
+    """Return the most recent non-superseded site visit for a leads.new record, or False."""
+    return lead.sudo().site_visit_ids.filtered(
+        lambda v: v.status_id.code != "superseded"
+    )[:1]
+
+
 def _serialize_primary_lead(lead) -> dict:
     """
     Serialize a leads.new record into the unified activity shape.
     """
     prop = lead.property_base_id
+    visit = _get_latest_active_visit(lead)
+    s = visit.status_id if visit else None
+    feedback_code = (visit.feedback_option_id.code or None) if visit else None
+    feedback_general = feedback_code if (s and (s.is_cancelled_status or s.is_no_show_status)) else None
+    feedback_done = feedback_code if (s and s.is_completed_status) else None
     return {
         "type": "primary",
+        "lead_id": lead.id,
         "lead_name": lead.name or None,
         "lead_phone": lead.phone or None,
         "source": lead.source_id.name or None,
@@ -77,46 +90,52 @@ def _serialize_primary_lead(lead) -> dict:
         "site_visit_date": (
             lead.site_visit_date_only.isoformat() if lead.site_visit_date_only else None
         ),
-        "remarks": lead.remarks or None,
-        "feedback_general": lead.feedback_general or None,
-        "feedback_site_visit_done": lead.feedback_site_visit_done or None,
+        "remarks": (visit.feedback_note or None) if visit else None,
+        "feedback_general": feedback_general,
+        "feedback_site_visit_done": feedback_done,
     }
 
 
-def _serialize_recommended_lead(interest) -> dict:
-    """Serialise a lead.property.interest record into the unified activity shape."""
-    prop = interest.property_base_id
-    parent_lead = interest.lead_id
+def _serialize_recommended_lead(inquiry) -> dict:
+    """Serialise a recommended leads.new record into the unified activity shape."""
+    prop = inquiry.sudo().property_base_id
+    parent_lead = inquiry.sudo().parent_inquiry_id
+    visit = _get_latest_active_visit(inquiry)
+    s = visit.status_id if visit else None
+    feedback_code = (visit.feedback_option_id.code or None) if visit else None
+    feedback_general = feedback_code if (s and (s.is_cancelled_status or s.is_no_show_status)) else None
+    feedback_done = feedback_code if (s and s.is_completed_status) else None
     return {
         "type": "recommended",
+        "lead_id": inquiry.id,
         "lead_name": parent_lead.name if parent_lead else None,
         "lead_phone": parent_lead.phone if parent_lead else None,
         "source": parent_lead.source_id.name if parent_lead else None,
         "property_tag": prop.property_tag if prop else None,
         "property_bhk": prop.bhk if prop else None,
         "property_location": prop.location if prop else None,
-        # For recommended, the inquiry datetime is when the interest record was created
+        # For recommended, inquiry_datetime is when the recommended inquiry was created
         "inquiry_datetime": (
-            interest.create_date.isoformat() if interest.create_date else None
+            inquiry.create_date.isoformat() if inquiry.create_date else None
         ),
-        "current_status": interest.current_status or None,
-        # first_contacted_on lives on the parent lead
+        "current_status": inquiry.current_status or None,
+        # first_contacted_on lives on the parent primary lead
         "first_contacted_on": (
             parent_lead.first_contact_datetime.isoformat()
             if parent_lead and parent_lead.first_contact_datetime
             else None
         ),
         "site_visit_datetime": (
-            interest.site_visit_date.isoformat() if interest.site_visit_date else None
+            inquiry.site_visit_date.isoformat() if inquiry.site_visit_date else None
         ),
         "site_visit_date": (
-            interest.site_visit_date_only.isoformat()
-            if interest.site_visit_date_only
+            inquiry.site_visit_date_only.isoformat()
+            if inquiry.site_visit_date_only
             else None
         ),
-        "remarks": interest.remarks or None,
-        "feedback_general": interest.feedback_general or None,
-        "feedback_site_visit_done": interest.feedback_site_visit_done or None,
+        "remarks": (visit.feedback_note or None) if visit else None,
+        "feedback_general": feedback_general,
+        "feedback_site_visit_done": feedback_done,
     }
 
 

--- a/custom_addons/leads/controllers/seller/funnel.py
+++ b/custom_addons/leads/controllers/seller/funnel.py
@@ -164,12 +164,12 @@ class SellerFunnelController(http.Controller):
             status = lead.current_status or "other"
             stage_counts[status] += 1
 
-        recommended_interests = get_recommended_leads_for_tags(request.env, tags)
-        for interest in recommended_interests:
-            status = interest.current_status or "other"
+        recommended_leads = get_recommended_leads_for_tags(request.env, tags)
+        for inquiry in recommended_leads:
+            status = inquiry.current_status or "other"
             stage_counts[status] += 1
 
-        total = len(primary_leads) + len(recommended_interests)
+        total = len(primary_leads) + len(recommended_leads)
 
         # Build stages dict — ensure all known stages are present even if zero
         def pct(count):

--- a/custom_addons/leads/controllers/seller/portal_performance.py
+++ b/custom_addons/leads/controllers/seller/portal_performance.py
@@ -122,18 +122,12 @@ class SellerPortalPerformanceController(http.Controller):
             source_data[source_name]["primary_leads"] += 1
             source_data[source_name]["statuses"][lead.current_status or "other"] += 1
 
-        recommended_interests = get_recommended_leads_for_tags(request.env, tags)
-        for interest in recommended_interests:
-            source_name = (
-                interest.lead_id.source_id.name
-                if interest.lead_id and interest.lead_id.source_id
-                else "Unknown"
-            )
+        recommended_leads = get_recommended_leads_for_tags(request.env, tags)
+        for inquiry in recommended_leads:
+            source_name = inquiry.source_id.name if inquiry.source_id else "Unknown"
             source_data[source_name]["total_leads"] += 1
             source_data[source_name]["recommended_leads"] += 1
-            source_data[source_name]["statuses"][
-                interest.current_status or "other"
-            ] += 1
+            source_data[source_name]["statuses"][inquiry.current_status or "other"] += 1
 
         serialised = {}
         for source_name, block in source_data.items():

--- a/custom_addons/leads/controllers/seller/property_dashboard.py
+++ b/custom_addons/leads/controllers/seller/property_dashboard.py
@@ -29,13 +29,6 @@ _logger = logging.getLogger(__name__)
 
 _EMPTY_FEEDBACK = {None, "", "other", False}
 
-
-def _get_latest_active_visit(lead):
-    """Return the most recent non-superseded site visit for a leads.new record, or False."""
-    return lead.sudo().site_visit_ids.filtered(
-        lambda v: v.status_id.code != "superseded"
-    )[:1]
-
 # Status → display bucket used for KPI cards.
 # "lead" (initial / never contacted) is intentionally absent — those inquiries
 # count toward the total but not toward any specific sub-bucket KPI.
@@ -62,11 +55,6 @@ _STATUS_BUCKET = {
 def _serialize_lead(lead, rec_type="primary"):
     prop = lead.property_base_id
     parent = lead
-    visit = _get_latest_active_visit(lead)
-    s = visit.status_id if visit else None
-    feedback_code = (visit.feedback_option_id.code or None) if visit else None
-    feedback_general = feedback_code if (s and (s.is_cancelled_status or s.is_no_show_status)) else None
-    feedback_done = feedback_code if (s and s.is_completed_status) else None
     return {
         "type": rec_type,
         "lead_id": parent.id if parent else None,
@@ -86,9 +74,9 @@ def _serialize_lead(lead, rec_type="primary"):
         "site_visit_datetime": (
             lead.site_visit_date.isoformat() if lead.site_visit_date else None
         ),
-        "feedback_general": feedback_general,
-        "feedback_site_visit_done": feedback_done,
-        "remarks": (visit.feedback_note or None) if visit else None,
+        "feedback_general": lead.feedback_general or None,
+        "feedback_site_visit_done": lead.feedback_site_visit_done or None,
+        "remarks": lead.remarks or None,
     }
 
 
@@ -372,11 +360,6 @@ class PropertyActivityDashboardController(http.Controller):
         for row in list(primary_leads) + list(recommended):
             rec_type = row.inquiry_type or "primary"
             parent = row
-            visit = _get_latest_active_visit(row)
-            sv = visit.status_id if visit else None
-            feedback_code = (visit.feedback_option_id.code or None) if visit else None
-            feedback_done = feedback_code if (sv and sv.is_completed_status) else None
-            feedback_general = feedback_code if (sv and (sv.is_cancelled_status or sv.is_no_show_status)) else None
             writer.writerow([
                 rec_type,
                 row.create_date.strftime("%Y-%m-%d") if row.create_date else "",
@@ -386,9 +369,9 @@ class PropertyActivityDashboardController(http.Controller):
                 (parent.user_id.name if parent and parent.user_id else "") or "",
                 row.current_status or "",
                 row.site_visit_date_only.isoformat() if row.site_visit_date_only else "",
-                feedback_done or "",
-                feedback_general or "",
-                (visit.feedback_note or "") if visit else "",
+                row.feedback_site_visit_done or "",
+                row.feedback_general or "",
+                row.remarks or "",
             ])
 
         filename = f"property_activity_{prop.property_tag or property_id}.csv"

--- a/custom_addons/leads/controllers/seller/property_dashboard.py
+++ b/custom_addons/leads/controllers/seller/property_dashboard.py
@@ -29,6 +29,13 @@ _logger = logging.getLogger(__name__)
 
 _EMPTY_FEEDBACK = {None, "", "other", False}
 
+
+def _get_latest_active_visit(lead):
+    """Return the most recent non-superseded site visit for a leads.new record, or False."""
+    return lead.sudo().site_visit_ids.filtered(
+        lambda v: v.status_id.code != "superseded"
+    )[:1]
+
 # Status → display bucket used for KPI cards.
 # "lead" (initial / never contacted) is intentionally absent — those inquiries
 # count toward the total but not toward any specific sub-bucket KPI.
@@ -55,6 +62,11 @@ _STATUS_BUCKET = {
 def _serialize_lead(lead, rec_type="primary"):
     prop = lead.property_base_id
     parent = lead
+    visit = _get_latest_active_visit(lead)
+    s = visit.status_id if visit else None
+    feedback_code = (visit.feedback_option_id.code or None) if visit else None
+    feedback_general = feedback_code if (s and (s.is_cancelled_status or s.is_no_show_status)) else None
+    feedback_done = feedback_code if (s and s.is_completed_status) else None
     return {
         "type": rec_type,
         "lead_id": parent.id if parent else None,
@@ -74,9 +86,9 @@ def _serialize_lead(lead, rec_type="primary"):
         "site_visit_datetime": (
             lead.site_visit_date.isoformat() if lead.site_visit_date else None
         ),
-        "feedback_general": lead.feedback_general or None,
-        "feedback_site_visit_done": lead.feedback_site_visit_done or None,
-        "remarks": lead.remarks or None,
+        "feedback_general": feedback_general,
+        "feedback_site_visit_done": feedback_done,
+        "remarks": (visit.feedback_note or None) if visit else None,
     }
 
 
@@ -360,6 +372,11 @@ class PropertyActivityDashboardController(http.Controller):
         for row in list(primary_leads) + list(recommended):
             rec_type = row.inquiry_type or "primary"
             parent = row
+            visit = _get_latest_active_visit(row)
+            sv = visit.status_id if visit else None
+            feedback_code = (visit.feedback_option_id.code or None) if visit else None
+            feedback_done = feedback_code if (sv and sv.is_completed_status) else None
+            feedback_general = feedback_code if (sv and (sv.is_cancelled_status or sv.is_no_show_status)) else None
             writer.writerow([
                 rec_type,
                 row.create_date.strftime("%Y-%m-%d") if row.create_date else "",
@@ -369,9 +386,9 @@ class PropertyActivityDashboardController(http.Controller):
                 (parent.user_id.name if parent and parent.user_id else "") or "",
                 row.current_status or "",
                 row.site_visit_date_only.isoformat() if row.site_visit_date_only else "",
-                row.feedback_site_visit_done or "",
-                row.feedback_general or "",
-                row.remarks or "",
+                feedback_done or "",
+                feedback_general or "",
+                (visit.feedback_note or "") if visit else "",
             ])
 
         filename = f"property_activity_{prop.property_tag or property_id}.csv"

--- a/custom_addons/leads/controllers/seller/summary.py
+++ b/custom_addons/leads/controllers/seller/summary.py
@@ -95,8 +95,8 @@ class SellerSummaryController(http.Controller):
         # Primary leads (leads.new records linked to the owner's properties)
         primary_leads = get_primary_leads_for_tags(request.env, tags)
 
-        # Recommended leads (lead.property.interest)
-        recommended_interests = get_recommended_leads_for_tags(request.env, tags)
+        # Recommended leads — leads.new records with inquiry_type='recommended'
+        recommended_leads = get_recommended_leads_for_tags(request.env, tags)
 
         # Source breakdown
         source_breakdown = defaultdict(lambda: {"primary": 0, "recommended": 0})
@@ -105,14 +105,8 @@ class SellerSummaryController(http.Controller):
             source_name = lead.source_id.name if lead.source_id else "Unknown"
             source_breakdown[source_name]["primary"] += 1
 
-        # Recommended leads come via lead.property.interest; source lives on
-        # the parent leads.new record.
-        for interest in recommended_interests:
-            source_name = (
-                interest.lead_id.source_id.name
-                if interest.lead_id and interest.lead_id.source_id
-                else "Unknown"
-            )
+        for inquiry in recommended_leads:
+            source_name = inquiry.source_id.name if inquiry.source_id else "Unknown"
             source_breakdown[source_name]["recommended"] += 1
 
         data = {
@@ -120,9 +114,9 @@ class SellerSummaryController(http.Controller):
             "properties": tags,
             "tag_filter": tag_filter,
             "inquiries": {
-                "total": len(primary_leads) + len(recommended_interests),
+                "total": len(primary_leads) + len(recommended_leads),
                 "primary": len(primary_leads),
-                "recommended": len(recommended_interests),
+                "recommended": len(recommended_leads),
                 "source_breakdown": dict(source_breakdown),
             },
         }

--- a/custom_addons/leads/controllers/shared/property_resolver.py
+++ b/custom_addons/leads/controllers/shared/property_resolver.py
@@ -114,6 +114,7 @@ def get_primary_leads_for_tags(env, property_tags: list[str]):
         .search(
             [
                 ("property_base_id", "in", props.ids),
+                ("inquiry_type", "=", "primary"),
             ],
         )
     )
@@ -121,8 +122,8 @@ def get_primary_leads_for_tags(env, property_tags: list[str]):
 
 def get_recommended_leads_for_tags(env, property_tags: list[str]):
     """
-    Return all lead.property.interest records where the recommended
-    property belongs to the seller's portfolio.
+    Return all leads.new records with inquiry_type='recommended' where the
+    recommended property belongs to the seller's portfolio.
 
     Parameters
     ----------
@@ -131,10 +132,10 @@ def get_recommended_leads_for_tags(env, property_tags: list[str]):
 
     Returns
     -------
-    lead.property.interest recordset
+    leads.new recordset  (inquiry_type='recommended')
     """
     if not property_tags:
-        return env["lead.property.interest"].sudo().browse([])
+        return env["leads.new"].sudo().browse([])
 
     props = (
         env["property.base"]
@@ -147,11 +148,12 @@ def get_recommended_leads_for_tags(env, property_tags: list[str]):
     )
 
     return (
-        env["lead.property.interest"]
+        env["leads.new"]
         .sudo()
         .search(
             [
                 ("property_base_id", "in", props.ids),
+                ("inquiry_type", "=", "recommended"),
             ],
         )
     )

--- a/custom_addons/leads/tests/test_seller_activity_api.py
+++ b/custom_addons/leads/tests/test_seller_activity_api.py
@@ -522,14 +522,12 @@ class TestSellerActivityAPI(PortalLeadTestCase):
                 property_base_id=self.test_property.id,
             )
 
-        # Create 2 recommended
+        # Create 2 recommended inquiries (leads.new with inquiry_type='recommended')
         for i in range(2):
-            lead = self.create_portal_lead(phone=f"71717171{i:02d}")
-            self.env["lead.property.interest"].create(
-                {
-                    "lead_id": lead.id,
-                    "property_base_id": self.test_property.id,
-                },
+            self.create_portal_lead(
+                phone=f"71717171{i:02d}",
+                inquiry_type="recommended",
+                property_base_id=self.test_property.id,
             )
 
         primary_leads = get_primary_leads_for_tags(self.env, tags)

--- a/custom_addons/leads/tests/test_seller_summary_api.py
+++ b/custom_addons/leads/tests/test_seller_summary_api.py
@@ -429,18 +429,18 @@ class TestSellerSummaryAPI(PortalLeadTestCase):
         lead_1 = self.create_portal_lead(phone="6666666666")
         lead_2 = self.create_portal_lead(phone="5555555555")
 
-        # Create interests
-        interest_1 = self.env["lead.property.interest"].create(
-            {
-                "lead_id": lead_1.id,
-                "property_base_id": self.test_property.id,
-            },
+        # Create recommended inquiries (leads.new with inquiry_type='recommended')
+        rec_1 = self.create_portal_lead(
+            phone="6666666666",
+            inquiry_type="recommended",
+            parent_inquiry_id=lead_1.id,
+            property_base_id=self.test_property.id,
         )
-        interest_2 = self.env["lead.property.interest"].create(
-            {
-                "lead_id": lead_2.id,
-                "property_base_id": self.test_property_2.id,
-            },
+        rec_2 = self.create_portal_lead(
+            phone="5555555555",
+            inquiry_type="recommended",
+            parent_inquiry_id=lead_2.id,
+            property_base_id=self.test_property_2.id,
         )
 
         # ACT
@@ -448,9 +448,9 @@ class TestSellerSummaryAPI(PortalLeadTestCase):
 
         # ASSERT
         self.assertEqual(len(recommended), 2, "Should return 2 recommended interests")
-        interest_ids = set(recommended.ids)
-        self.assertTrue(interest_1.id in interest_ids)
-        self.assertTrue(interest_2.id in interest_ids)
+        rec_ids = set(recommended.ids)
+        self.assertTrue(rec_1.id in rec_ids)
+        self.assertTrue(rec_2.id in rec_ids)
 
     def test_15_get_recommended_leads_empty_tags(self):
         """
@@ -580,20 +580,16 @@ class TestSellerSummaryAPI(PortalLeadTestCase):
                 property_base_id=self.test_property.id,
             )
 
-        # Create 2 recommended interests
-        lead = self.create_portal_lead(phone="4444444444")
-        self.env["lead.property.interest"].create(
-            {
-                "lead_id": lead.id,
-                "property_base_id": self.test_property_2.id,
-            },
+        # Create 2 recommended inquiries (leads.new with inquiry_type='recommended')
+        self.create_portal_lead(
+            phone="4444444444",
+            inquiry_type="recommended",
+            property_base_id=self.test_property_2.id,
         )
-        lead_2 = self.create_portal_lead(phone="3333333333")
-        self.env["lead.property.interest"].create(
-            {
-                "lead_id": lead_2.id,
-                "property_base_id": self.test_property.id,
-            },
+        self.create_portal_lead(
+            phone="3333333333",
+            inquiry_type="recommended",
+            property_base_id=self.test_property.id,
         )
 
         # ACT

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# run_tests.sh — Run Odoo tests locally, mirroring the GitHub Actions workflow.
+#
+# Usage:
+#   ./run_tests.sh                    # run all tagged modules
+#   ./run_tests.sh leads              # run only the leads module
+#   ./run_tests.sh leads properties   # run specific modules (space-separated)
+#
+# Prerequisites:
+#   - Docker running
+#   - No existing service on port 5432 (or pass DB_PORT=5433 etc.)
+#
+# Environment variable overrides (all optional):
+#   DB_PORT      — host port for Postgres (default: 5432)
+#   KEEP_DB      — if set to "1", the Postgres container is left running after tests
+#   REBUILD      — if set to "1", forces a fresh Docker image build even if one exists
+#   LOG_LEVEL    — odoo log level (default: test)
+
+set -euo pipefail
+
+# ── Configurable defaults ────────────────────────────────────────────────────
+DB_PORT="${DB_PORT:-5432}"
+DB_USER="odoo"
+DB_PASSWORD="odoo"
+DB_NAME="odoo_test_db"
+IMAGE_NAME="my-odoo-image"
+CONTAINER_NAME="odoo_test_postgres"
+LOG_LEVEL="${LOG_LEVEL:-test}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Modules/tags to test — can be overridden by positional arguments
+DEFAULT_MODULES="leads,lead_suggestor,cleardeals_dashboards,properties"
+DEFAULT_TAGS="/leads,/lead_suggestor,/cleardeals_dashboards,/properties"
+
+if [[ $# -gt 0 ]]; then
+    # Build comma-separated lists from positional args
+    IFS=',' MODULE_LIST="${*// /,}"
+    unset IFS
+    MODULES="${MODULE_LIST}"
+    TAGS=$(echo "${MODULE_LIST}" | sed 's/,/,\//g; s/^/\//')
+else
+    MODULES="${DEFAULT_MODULES}"
+    TAGS="${DEFAULT_TAGS}"
+fi
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Colour
+
+log()  { echo -e "${CYAN}[test]${NC} $*"; }
+ok()   { echo -e "${GREEN}[  OK]${NC} $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+fail() { echo -e "${RED}[FAIL]${NC} $*"; exit 1; }
+
+# ── Cleanup handler ──────────────────────────────────────────────────────────
+cleanup() {
+    if [[ "${KEEP_DB:-0}" == "1" ]]; then
+        warn "KEEP_DB=1 — leaving Postgres container '${CONTAINER_NAME}' running."
+        warn "Stop it manually with: docker rm -f ${CONTAINER_NAME}"
+    else
+        log "Stopping and removing Postgres container…"
+        docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# ── 1. Check Docker is available ─────────────────────────────────────────────
+log "Checking Docker…"
+docker info > /dev/null 2>&1 || fail "Docker is not running. Please start Docker Desktop."
+ok "Docker is running."
+
+# ── 2. Build Odoo image ──────────────────────────────────────────────────────
+if [[ "${REBUILD:-0}" == "1" ]] || ! docker image inspect "${IMAGE_NAME}" > /dev/null 2>&1; then
+    log "Building Odoo Docker image '${IMAGE_NAME}'…"
+    docker build -t "${IMAGE_NAME}" "${SCRIPT_DIR}"
+    ok "Image built."
+else
+    ok "Image '${IMAGE_NAME}' already exists (use REBUILD=1 to force a rebuild)."
+fi
+
+# ── 3. Start Postgres ────────────────────────────────────────────────────────
+log "Starting Postgres container on port ${DB_PORT}…"
+
+# Remove any stale container with the same name
+docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+
+docker run -d \
+    --name "${CONTAINER_NAME}" \
+    -e POSTGRES_USER="${DB_USER}" \
+    -e POSTGRES_PASSWORD="${DB_PASSWORD}" \
+    -e POSTGRES_DB="${DB_NAME}" \
+    -p "${DB_PORT}:5432" \
+    postgres:17
+
+# ── 4. Wait for Postgres to be ready ─────────────────────────────────────────
+log "Waiting for Postgres to be ready…"
+MAX_RETRIES=30
+RETRY=0
+until docker exec "${CONTAINER_NAME}" pg_isready -U "${DB_USER}" > /dev/null 2>&1; do
+    RETRY=$((RETRY + 1))
+    if [[ ${RETRY} -ge ${MAX_RETRIES} ]]; then
+        fail "Postgres did not become ready after ${MAX_RETRIES} attempts."
+    fi
+    sleep 1
+done
+ok "Postgres is ready."
+
+# ── 5. Run Odoo tests ────────────────────────────────────────────────────────
+log "Running tests for modules: ${MODULES}"
+log "Test tags: ${TAGS}"
+echo ""
+
+docker run --rm \
+    --network host \
+    -v "${SCRIPT_DIR}/custom_addons:/mnt/extra-addons" \
+    -e HOST=localhost \
+    -e PORT="${DB_PORT}" \
+    -e USER="${DB_USER}" \
+    -e PASSWORD="${DB_PASSWORD}" \
+    "${IMAGE_NAME}" \
+    odoo -d "${DB_NAME}" \
+        --db_host=localhost \
+        --db_port="${DB_PORT}" \
+        --db_user="${DB_USER}" \
+        --db_password="${DB_PASSWORD}" \
+        --addons-path=/mnt/extra-addons,/usr/lib/python3/dist-packages/odoo/addons \
+        -i "${MODULES}" \
+        --test-enable \
+        --test-tags "${TAGS}" \
+        --stop-after-init \
+        --log-level="${LOG_LEVEL}"
+
+# docker run exits with non-zero if Odoo reports test failures
+TEST_EXIT=$?
+
+echo ""
+if [[ ${TEST_EXIT} -eq 0 ]]; then
+    ok "All tests passed."
+else
+    fail "Tests finished with exit code ${TEST_EXIT} — check the output above for failures."
+fi


### PR DESCRIPTION
This pull request refactors and enhances the buyer and seller activity APIs to unify how recommended leads are represented, improve feedback and remarks handling, and clarify API documentation. The changes move away from using separate interest records for recommendations, instead treating recommended leads as their own inquiry records. Feedback and remarks fields are now consistently derived from the latest active site visit, and API documentation is updated to reflect these changes.

**API Response and Documentation Improvements:**

* Updated API documentation (`API_DOCUMENTATION.md`) to clarify that recommended properties are now represented as child inquiry records, not separate interest records. Added new fields such as `lead_id`, `interest_id`, `property_link`, and improved descriptions for feedback and remarks fields in both primary and recommended inquiry objects. Example responses have been updated accordingly. [[1]](diffhunk://#diff-dfd9956b59dea3d41eb075755b84205a1274c6bca05f935a66c2afd0938680beR338-R351) [[2]](diffhunk://#diff-dfd9956b59dea3d41eb075755b84205a1274c6bca05f935a66c2afd0938680beL362-R376) [[3]](diffhunk://#diff-dfd9956b59dea3d41eb075755b84205a1274c6bca05f935a66c2afd0938680beR393-R401) [[4]](diffhunk://#diff-dfd9956b59dea3d41eb075755b84205a1274c6bca05f935a66c2afd0938680beR414-R423) [[5]](diffhunk://#diff-dfd9956b59dea3d41eb075755b84205a1274c6bca05f935a66c2afd0938680beR664-R678) [[6]](diffhunk://#diff-dfd9956b59dea3d41eb075755b84205a1274c6bca05f935a66c2afd0938680beR694)

**Buyer Activity API Refactor (`buyer/activity.py`):**

* Refactored serialization logic to treat recommended leads as `leads.new` child inquiry records, not separate interest records. Updated feedback and remarks fields to pull from the latest non-superseded site visit, and included new fields like `lead_id` and improved feedback code handling. [[1]](diffhunk://#diff-512f5df7b0bb098124684ff2d53085ae0d968ded1cc68de569747e1ce48e8e7fR83-R89) [[2]](diffhunk://#diff-512f5df7b0bb098124684ff2d53085ae0d968ded1cc68de569747e1ce48e8e7fL95-R137) [[3]](diffhunk://#diff-512f5df7b0bb098124684ff2d53085ae0d968ded1cc68de569747e1ce48e8e7fR149-R151)
* Improved summary statistics to count site visits and properties using the new inquiry structure and visit status flags, ensuring accurate milestone counts. [[1]](diffhunk://#diff-512f5df7b0bb098124684ff2d53085ae0d968ded1cc68de569747e1ce48e8e7fL166-R190) [[2]](diffhunk://#diff-512f5df7b0bb098124684ff2d53085ae0d968ded1cc68de569747e1ce48e8e7fL187-R229)

**Seller Activity API Refactor (`seller/activity.py`):**

* Unified serialization for primary and recommended leads, using the same approach as the buyer API for remarks and feedback fields. Recommended leads are now also `leads.new` records with `inquiry_type='recommended'`. [[1]](diffhunk://#diff-2e72e7d96f09a5aa191522d1b5ebe3f00ee6d2d80ae1a3760d69c23f1877f295R54-R73) [[2]](diffhunk://#diff-2e72e7d96f09a5aa191522d1b5ebe3f00ee6d2d80ae1a3760d69c23f1877f295L80-R138)

**Supporting Seller Analytics Updates:**

* Updated seller analytics and summary endpoints to use the new recommended lead structure, replacing references to interest records with recommended inquiry records for stage counts and source breakdowns. [[1]](diffhunk://#diff-1505b48cad85e9175edcd10c6387d1aefe5d200f6fbf9ee902ee6dc1c8115c96L167-R172) [[2]](diffhunk://#diff-45384a4092ba559527932ab3a7391087e4a5b3e968518e99b70e7f4b279301daL125-R130) [[3]](diffhunk://#diff-ee2830b58bd110b11686c87bf91448511434a29a861267610052a9c2573b9153L98-R99)Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
