### PR TITLE
Update GitHub Actions for development_19 and enhance site visit API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['development_19', '19.0']
   pull_request:
-    branches: ['19.0']
+    branches: ['19.0', 'development_19']
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ venv
 
 odoo-db-data/
 odoo-web-data/
+odoo-dev-db-data/
+odoo-dev-web-data/
 
 docker-compose.override.yml
 

--- a/custom_addons/leads/controllers/buyer/site_visits.py
+++ b/custom_addons/leads/controllers/buyer/site_visits.py
@@ -2,8 +2,7 @@
 GET /api/track/lead/site-visits
 ---------------------------------
 Returns all site visits for a buyer across ALL of their inquiries —
-both primary leads (leads.new) and recommended property interests
-(lead.property.interest).
+both primary and recommended leads.new records.
 
 Classification rules  (mirrors seller site-visits logic exactly)
 --------------------
@@ -106,17 +105,19 @@ from ..shared.response_utils import error_response, success_response
 _logger = logging.getLogger(__name__)
 
 
-def _get_latest_active_visit(lead):
+def _get_active_visits(lead):
     """
-    Return the latest non-superseded lead.site.visit for this inquiry.
+    Return all non-superseded lead.site.visit records for this inquiry.
 
-    "Superseded" visits are the old, now-closed leg of a reschedule chain.
-    They carry historical context but do not represent a current appointment.
-    We filter them out so the API always reflects the actual current state.
+    Superseded visits are the closed leg of a reschedule chain and must be
+    skipped so the API does not double-count rescheduled appointments.
+    All other visits (scheduled, rescheduled, completed, cancelled, no-show)
+    are included — a lead may have multiple active visits (e.g. one completed
+    visit followed by a second scheduled visit).
     """
     return lead.sudo().site_visit_ids.filtered(
         lambda v: v.status_id.code != "superseded"
-    )[:1]
+    )
 
 
 def _classify_visit(visit, now: datetime) -> str:
@@ -162,8 +163,24 @@ def _visit_from_lead(lead, visit, now: datetime) -> tuple[str, datetime, dict]:
     # for informational display.
     current_status_str = "site_visit_done" if s.is_completed_status else "site_visit_scheduled"
 
-    feedback_code = visit.feedback_option_id.code or None
+    # Primary source: feedback_option_id on the visit record (new model).
+    # Fallback: legacy Selection fields on leads.new for visits where the RM
+    # set feedback directly on the lead form rather than through the visit.
+    feedback_option = visit.feedback_option_id
+    feedback_code = feedback_option.code or None
+    feedback_label = feedback_option.name or None
     feedback_note = visit.feedback_note or None
+
+    if not feedback_code:
+        _general_map = dict(lead._fields["feedback_general"].selection)
+        _done_map = dict(lead._fields["feedback_site_visit_done"].selection)
+        fallback_general_code = lead.feedback_general or None
+        fallback_general_label = _general_map.get(fallback_general_code) if fallback_general_code else None
+        fallback_done_code = lead.feedback_site_visit_done or None
+        fallback_done_label = _done_map.get(fallback_done_code) if fallback_done_code else None
+    else:
+        fallback_general_code = fallback_general_label = None
+        fallback_done_code = fallback_done_label = None
 
     record = {
         "inquiry_type": lead.inquiry_type or "primary",
@@ -181,16 +198,19 @@ def _visit_from_lead(lead, visit, now: datetime) -> tuple[str, datetime, dict]:
             visit.scheduled_date.isoformat() if visit.scheduled_date else None
         ),
         "current_status": current_status_str,
+        "status_name": s.name or None,
         "remarks": feedback_note,
     }
 
     if bucket == "pending_feedback":
         record["note"] = "Visit date has passed — awaiting RM feedback"
     elif bucket == "cancelled":
-        record["feedback_general"] = feedback_code
+        record["feedback_general"] = feedback_code or fallback_general_code
+        record["feedback_general_label"] = feedback_label or fallback_general_label
         record["note"] = "Visit did not occur due to buyer status"
     elif bucket == "completed":
-        record["feedback_site_visit_done"] = feedback_code
+        record["feedback_site_visit_done"] = feedback_code or fallback_done_code
+        record["feedback_site_visit_done_label"] = feedback_label or fallback_done_label
 
     return bucket, visit.scheduled_datetime, record
 
@@ -233,14 +253,10 @@ class BuyerSiteVisitsController(http.Controller):
         for lead in leads:
             # Covers both primary and recommended inquiries: each leads.new
             # record (regardless of inquiry_type) owns its own site visits
-            # through the lead.site.visit model.  Legacy lead.property.interest
-            # recommended visits are not shown here — they predate the visit
-            # model and have no lead.site.visit records.
-            visit = _get_latest_active_visit(lead)
-            if not visit:
-                continue
-            bucket, sort_key, record = _visit_from_lead(lead, visit, now)
-            buckets[bucket].append((sort_key, record))
+            # through the lead.site.visit model.
+            for visit in _get_active_visits(lead):
+                bucket, sort_key, record = _visit_from_lead(lead, visit, now)
+                buckets[bucket].append((sort_key, record))
 
         # ── Sort each bucket ──────────────────────────────────────────────────
         # upcoming         → soonest first (ascending)

--- a/custom_addons/leads/controllers/seller/site_visits.py
+++ b/custom_addons/leads/controllers/seller/site_visits.py
@@ -117,49 +117,25 @@ from ..shared.response_utils import error_response, success_response
 
 _logger = logging.getLogger(__name__)
 
-# Only statuses used by the legacy lead.property.interest snapshot path.
-_LEGACY_VISIT_STATUSES = {"site_visit_scheduled", "site_visit_done"}
 
-# feedback_general values treated as "nothing meaningful logged yet"
-_EMPTY_FEEDBACK = {None, "", "other", False}
-
-FEEDBACK_GENERAL_MAP = {
-    "buyer_did_not_visit_property": "Buyer Did Not Visit Property",
-    "buyer_not_interested": "Buyer Not Interested",
-    "buyer_not_picking_call": "Buyer Not Picking Call",
-    "visit_needs_to_be_rescheduled": "Visit Needs to be Rescheduled",
-    "other": "Other",
-}
-
-FEEDBACK_DONE_MAP = {
-    "buyer_liked_property": "Buyer Liked Property",
-    "buyer_requirement_closed": "Buyer Requirement Closed",
-    "buyer_visit_from_outside": "Buyer Visit From Outside",
-    "buyer_not_pickup_call": "Buyer Not Picking Call",
-    "planning_for_second_visit": "Planning for Second Visit",
-    "negotiation_stage": "Negotiation Stage",
-    "visit_done_confirmed_by_owner": "Visit Done - Confirmed by Owner",
-    "looking_for_more_options": "Looking for More Options",
-    "price_is_high": "Price is High",
-    "location_mismatch": "Location Mismatch",
-    "deal_closed": "Deal Closed",
-    "other": "Other",
-}
 
 
 # ── New visit-model helpers ────────────────────────────────────────────────
 
 
-def _get_latest_active_visit(lead):
+def _get_active_visits(lead):
     """
-    Return the latest non-superseded lead.site.visit for this inquiry.
+    Return all non-superseded lead.site.visit records for this inquiry.
 
     Superseded visits are the closed leg of a reschedule chain and must be
-    skipped so the API reflects the actual current appointment state.
+    skipped so the API does not double-count rescheduled appointments.
+    All other visits (scheduled, rescheduled, completed, cancelled, no-show)
+    are included — a lead may have multiple active visits (e.g. one completed
+    visit followed by a second scheduled visit).
     """
     return lead.sudo().site_visit_ids.filtered(
         lambda v: v.status_id.code != "superseded"
-    )[:1]
+    )
 
 
 def _classify_visit_new(visit, now: datetime) -> str:
@@ -192,8 +168,25 @@ def _visit_from_lead_model(lead, visit, now: datetime) -> tuple[str, datetime, d
     s = visit.status_id
 
     current_status_str = "site_visit_done" if s.is_completed_status else "site_visit_scheduled"
-    feedback_code = visit.feedback_option_id.code or None
+
+    # Primary source: feedback_option_id on the visit record (new model).
+    # Fallback: legacy Selection fields on leads.new for visits where the RM
+    # set feedback directly on the lead form rather than through the visit.
+    feedback_option = visit.feedback_option_id
+    feedback_code = feedback_option.code or None
+    feedback_label = feedback_option.name or None
     feedback_note = visit.feedback_note or None
+
+    if not feedback_code:
+        _general_map = dict(lead._fields["feedback_general"].selection)
+        _done_map = dict(lead._fields["feedback_site_visit_done"].selection)
+        fallback_general_code = lead.feedback_general or None
+        fallback_general_label = _general_map.get(fallback_general_code) if fallback_general_code else None
+        fallback_done_code = lead.feedback_site_visit_done or None
+        fallback_done_label = _done_map.get(fallback_done_code) if fallback_done_code else None
+    else:
+        fallback_general_code = fallback_general_label = None
+        fallback_done_code = fallback_done_label = None
 
     record = {
         "source": lead.inquiry_type or "primary",
@@ -209,91 +202,21 @@ def _visit_from_lead_model(lead, visit, now: datetime) -> tuple[str, datetime, d
             visit.scheduled_date.isoformat() if visit.scheduled_date else None
         ),
         "current_status": current_status_str,
+        "status_name": s.name or None,
         "remarks": feedback_note,
     }
 
     if bucket == "pending_feedback":
         record["note"] = "Visit date has passed — awaiting RM feedback"
     elif bucket == "cancelled":
-        record["feedback_general"] = feedback_code
+        record["feedback_general"] = feedback_code or fallback_general_code
+        record["feedback_general_label"] = feedback_label or fallback_general_label
         record["note"] = "Visit did not occur due to buyer status"
     elif bucket == "completed":
-        record["feedback_site_visit_done"] = feedback_code
+        record["feedback_site_visit_done"] = feedback_code or fallback_done_code
+        record["feedback_site_visit_done_label"] = feedback_label or fallback_done_label
 
     return bucket, visit.scheduled_datetime, record
-
-
-# ── Legacy snapshot helpers (lead.property.interest) ──────────────────────
-
-
-def _classify_legacy_visit(
-    current_status: str,
-    site_visit_date: datetime,
-    now: datetime,
-    feedback_general: str | None,
-) -> str:
-    """
-    Classify a legacy lead.property.interest record.
-
-    This path is retained for backward compatibility with interest records that
-    predate the lead.site.visit model.  New visits are handled by
-    _classify_visit_new / _visit_from_lead_model instead.
-    """
-    if current_status == "site_visit_done":
-        return "completed"
-
-    if current_status == "site_visit_scheduled":
-        if site_visit_date > now:
-            return "upcoming"
-        if feedback_general in _EMPTY_FEEDBACK:
-            return "pending_feedback"
-        return "cancelled"
-
-    return "pending_feedback"
-
-
-def _visit_from_recommended_legacy(interest, now: datetime) -> tuple[str, datetime, dict]:
-    """
-    Build (bucket, sort_key, record_dict) from a legacy lead.property.interest record.
-
-    Retained for backward compatibility with interest records that predate the
-    lead.site.visit model.  New recommended inquiries use leads.new +
-    lead.site.visit and are handled by _visit_from_lead_model instead.
-    """
-    parent = interest.lead_id
-    current_status = interest.current_status
-    site_visit_date = interest.site_visit_date
-    feedback_general = interest.feedback_general
-    feedback_site_visit_done = interest.feedback_site_visit_done
-
-    bucket = _classify_legacy_visit(current_status, site_visit_date, now, feedback_general)
-
-    record = {
-        "source": "recommended",
-        "lead_name": parent.name if parent else None,
-        "lead_phone": parent.phone if parent else None,
-        "property_tag": interest.property_base_id.property_tag if interest.property_base_id else None,
-        "property_bhk": interest.property_base_id.bhk if interest.property_base_id else None,
-        "property_location": interest.property_base_id.location if interest.property_base_id else None,
-        "site_visit_datetime": site_visit_date.isoformat() if site_visit_date else None,
-        "site_visit_date": interest.site_visit_date_only.isoformat() if interest.site_visit_date_only else None,
-        "current_status": current_status or None,
-        "remarks": interest.remarks or None,
-    }
-
-    if bucket == "pending_feedback":
-        record["note"] = "Visit date has passed — awaiting RM feedback"
-    elif bucket == "cancelled":
-        record["feedback_general"] = feedback_general
-        record["note"] = "Visit did not occur due to buyer status"
-    elif bucket == "completed":
-        record["feedback_site_visit_done"] = feedback_site_visit_done or None
-        if feedback_site_visit_done == "other":
-            record["remarks"] = interest.remarks or None
-        else:
-            record["remarks"] = None
-
-    return bucket, site_visit_date, record
 
 
 class SellerSiteVisitsController(http.Controller):
@@ -344,23 +267,14 @@ class SellerSiteVisitsController(http.Controller):
         }
 
         # ── All leads.new for the seller's properties (primary + recommended) ─
-        # get_primary_leads_for_tags returns all leads.new with property_base_id
-        # in the seller's property set — this covers both inquiry_type='primary'
-        # and inquiry_type='recommended' records transparently.
-        for lead in get_primary_leads_for_tags(request.env, tags):
-            visit = _get_latest_active_visit(lead)
-            if not visit:
-                continue
-            bucket, sort_key, record = _visit_from_lead_model(lead, visit, now)
-            buckets[bucket].append((sort_key, record))
-
-        # ── Legacy lead.property.interest records ─────────────────────────────
-        # Retained for visits created before the lead.site.visit model existed.
-        for interest in get_recommended_leads_for_tags(request.env, tags).filtered(
-            lambda i: i.site_visit_date and i.current_status in _LEGACY_VISIT_STATUSES,
-        ):
-            bucket, sort_key, record = _visit_from_recommended_legacy(interest, now)
-            buckets[bucket].append((sort_key, record))
+        all_leads = (
+            get_primary_leads_for_tags(request.env, tags)
+            | get_recommended_leads_for_tags(request.env, tags)
+        )
+        for lead in all_leads:
+            for visit in _get_active_visits(lead):
+                bucket, sort_key, record = _visit_from_lead_model(lead, visit, now)
+                buckets[bucket].append((sort_key, record))
 
         # ── Sort each bucket ──────────────────────────────────────────────────
         # upcoming         → soonest first (ascending)

--- a/custom_addons/leads/tests/test_buyer_site_visits_api.py
+++ b/custom_addons/leads/tests/test_buyer_site_visits_api.py
@@ -1012,8 +1012,8 @@ class TestBuyerSiteVisitsAPI(PortalLeadTestCase):
 
         # The API classifies this as "upcoming" because the new (non-superseded) visit
         # has a future datetime.  The controller reads from lead.site.visit directly.
-        from odoo.addons.leads.controllers.buyer.site_visits import _get_latest_active_visit
-        active_visit = _get_latest_active_visit(lead)
+        from odoo.addons.leads.controllers.buyer.site_visits import _get_active_visits
+        active_visit = _get_active_visits(lead)[:1]
         bucket = _classify_visit(active_visit, self.now)
         self.assertEqual(
             bucket,

--- a/custom_addons/leads/tests/test_seller_site_visits_api.py
+++ b/custom_addons/leads/tests/test_seller_site_visits_api.py
@@ -1056,7 +1056,7 @@ class TestSellerSiteVisitsAPI(PortalLeadTestCase):
         """
         from odoo.addons.leads.controllers.seller.site_visits import (
             _classify_visit_new,
-            _get_latest_active_visit,
+            _get_active_visits,
         )
 
         now = datetime.now()
@@ -1092,7 +1092,7 @@ class TestSellerSiteVisitsAPI(PortalLeadTestCase):
         )
 
         # The controller gets the latest non-superseded visit and classifies it.
-        active_visit = _get_latest_active_visit(lead)
+        active_visit = _get_active_visits(lead)[:1]
         bucket = _classify_visit_new(active_visit, now)
         self.assertEqual(
             bucket,


### PR DESCRIPTION
This pull request updates both the buyer and seller site visits APIs to return all non-superseded (active) site visits for each inquiry, instead of only the latest. It also improves feedback reporting by including both feedback codes and their human-readable labels, and removes legacy support for old recommended visit records. Additionally, the test workflows and corresponding tests have been updated to reflect these changes.

**API Enhancements:**

* Both buyer (`site_visits.py`) and seller (`site_visits.py`) APIs now return all non-superseded (`active`) visits per inquiry, not just the latest one. This ensures that multiple scheduled, completed, or cancelled visits are accurately represented. [[1]](diffhunk://#diff-59e24c751c5a59ff0f01eb67329cb90fc0f4ace71e14d36215ff2da216dc7e55L109-R120) [[2]](diffhunk://#diff-348b80ff9c32ec2cbff5093c1e8a43cadd5b68b860534ad3da05fd3f2882afccL120-R138) [[3]](diffhunk://#diff-59e24c751c5a59ff0f01eb67329cb90fc0f4ace71e14d36215ff2da216dc7e55L236-R257) [[4]](diffhunk://#diff-348b80ff9c32ec2cbff5093c1e8a43cadd5b68b860534ad3da05fd3f2882afccL347-L364)
* The APIs now return both feedback codes and their corresponding human-readable labels for each visit, improving frontend display and clarity. [[1]](diffhunk://#diff-59e24c751c5a59ff0f01eb67329cb90fc0f4ace71e14d36215ff2da216dc7e55L165-R184) [[2]](diffhunk://#diff-59e24c751c5a59ff0f01eb67329cb90fc0f4ace71e14d36215ff2da216dc7e55R201-R213) [[3]](diffhunk://#diff-348b80ff9c32ec2cbff5093c1e8a43cadd5b68b860534ad3da05fd3f2882afccL195-R190) [[4]](diffhunk://#diff-348b80ff9c32ec2cbff5093c1e8a43cadd5b68b860534ad3da05fd3f2882afccR205-L298)

**Legacy Code Removal:**

* The seller site visits API removes legacy code for handling old `lead.property.interest` recommended visit records, as all visits are now sourced from the new model. [[1]](diffhunk://#diff-348b80ff9c32ec2cbff5093c1e8a43cadd5b68b860534ad3da05fd3f2882afccL120-R138) [[2]](diffhunk://#diff-348b80ff9c32ec2cbff5093c1e8a43cadd5b68b860534ad3da05fd3f2882afccR205-L298) [[3]](diffhunk://#diff-348b80ff9c32ec2cbff5093c1e8a43cadd5b68b860534ad3da05fd3f2882afccL347-L364)

**Test and Workflow Updates:**

* Tests for both buyer and seller site visits have been updated to use the new `_get_active_visits` helper and to handle lists of visits. [[1]](diffhunk://#diff-dca0bc42a47b38bbfa31963f61780c1fac4a72fa0332c4ef95bae652651a49ffL1015-R1016) [[2]](diffhunk://#diff-83a6f7ed5d49bf70915aa00119ee2a30667b3dbe2b5d5554af840b7f1ac5b8e8L1059-R1059) [[3]](diffhunk://#diff-83a6f7ed5d49bf70915aa00119ee2a30667b3dbe2b5d5554af840b7f1ac5b8e8L1095-R1095)
* The GitHub Actions workflow for tests now triggers on both `development_19` and `19.0` branches for push and pull requests.

**Documentation:**

* API docstrings and comments have been updated to clarify that only the new visit model is supported and to reflect the new logic for visit selection and classification. [[1]](diffhunk://#diff-59e24c751c5a59ff0f01eb67329cb90fc0f4ace71e14d36215ff2da216dc7e55L5-R5) [[2]](diffhunk://#diff-59e24c751c5a59ff0f01eb67329cb90fc0f4ace71e14d36215ff2da216dc7e55L109-R120) [[3]](diffhunk://#diff-348b80ff9c32ec2cbff5093c1e8a43cadd5b68b860534ad3da05fd3f2882afccL120-R138)

These changes ensure more accurate and complete reporting of site visits, improved feedback data for consumers, and a cleaner, more maintainable codebase.Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
