### PR TITLE
Move cron disable migration to 19.0.1.6.0

### DIFF
--- a/custom_addons/properties/data/property_cron.xml
+++ b/custom_addons/properties/data/property_cron.xml
@@ -8,14 +8,16 @@
              Writes: API-sourced fields only (see API_WRITABLE_FIELDS in
                      property_sync.py).  Never writes manager-editable fields.
 
-             As of 19.0.1.4.0 the website pushes property create/update events
+             As of 19.0.1.6.0 the website pushes property create/update events
              to /api/v1/properties/webhook/{create,update} (controllers/webhooks.py),
              so this polling cron is left INACTIVE.  The method and the manual
              "Sync Properties from API" button are kept for backfill /
              reconciliation if a webhook is ever missed.
              NOTE: this file is noupdate="1", so on an already-installed DB the
              active=False below does not apply on upgrade — the
-             migrations/19.0.1.4.0/post-disable_cron.py script handles that.
+             migrations/19.0.1.6.0/post-disable_cron.py script handles that.
+             (Placed at 19.0.1.6.0 = the current module version so it runs on the
+             upgrade regardless of whichever prior version prod has installed.)
         ================================================================ -->
         <record id="ir_cron_sync_properties_from_api" model="ir.cron">
             <field name="name">Properties: Sync from Website API</field>

--- a/custom_addons/properties/migrations/19.0.1.6.0/post-disable_cron.py
+++ b/custom_addons/properties/migrations/19.0.1.6.0/post-disable_cron.py
@@ -32,6 +32,6 @@ def migrate(cr, version):
     )
     if cr.rowcount:
         _logger.info(
-            "properties 19.0.1.4.0: disabled legacy polling cron "
+            "properties 19.0.1.6.0: disabled legacy polling cron "
             "(ir_cron_sync_properties_from_api).",
         )


### PR DESCRIPTION
Relocate the legacy polling cron disabling migration from 19.0.1.4.0 to 19.0.1.6.0 (current module version). This ensures the migration runs on all upgrades regardless of the prior installed version, preventing the cron from remaining active on databases already past 19.0.1.4.0.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
